### PR TITLE
Mpu6500 support

### DIFF
--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -25,6 +25,19 @@
 #include "MPU6500_WE.h"
 
 
+xyzFloat::xyzFloat()
+    : xyzFloat(0.f, 0.f, 0.f)
+{
+    // intentionally empty
+}
+
+xyzFloat::xyzFloat(float const x, float const y, float const z)
+    : x(x)
+    , y(y)
+    , z(z)
+{
+    // intentionally empty
+}
 
 xyzFloat xyzFloat::operator+() const
 {

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -24,6 +24,49 @@
 
 #include "MPU6500_WE.h"
 
+
+
+xyzFloat xyzFloat::operator+() const
+{
+    return *this;
+}
+
+xyzFloat xyzFloat::operator-() const
+{
+    return xyzFloat{-x,
+                    -y,
+                    -z};
+}
+
+xyzFloat xyzFloat::operator+(xyzFloat const & summand) const
+{
+    return xyzFloat{x + summand.x,
+                    y + summand.y,
+                    z + summand.z};
+}
+
+xyzFloat xyzFloat::operator-(xyzFloat const & subtrahend) const
+{
+    return xyzFloat{x - subtrahend.x,
+                    y - subtrahend.y,
+                    z - subtrahend.z};
+}
+
+xyzFloat xyzFloat::operator*(float const operand) const
+{
+    return xyzFloat{x * operand,
+                    y * operand,
+                    z * operand};
+}
+
+xyzFloat xyzFloat::operator/(float const divisor) const
+{
+    return xyzFloat{x / divisor,
+                    y / divisor,
+                    z / divisor};
+}
+
+
 /* Registers MPU6500 */
 uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_X_GYRO     ;
 uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_Y_GYRO     ;
@@ -283,9 +326,7 @@ xyzFloat MPU6500_WE::getCorrectedAccRawValues(){
 
 xyzFloat MPU6500_WE::getGValues(){
     xyzFloat const acceleration = getCorrectedAccRawValues();
-    return xyzFloat{static_cast<float>(acceleration.x * accRangeFactor / 16384.0),
-                    static_cast<float>(acceleration.y * accRangeFactor / 16384.0),
-                    static_cast<float>(acceleration.z * accRangeFactor / 16384.0)};
+    return acceleration * (static_cast<float>(accRangeFactor) / 16384.0f);
 }
 
 xyzFloat MPU6500_WE::getAccRawValuesFromFifo(){
@@ -301,9 +342,7 @@ xyzFloat MPU6500_WE::getCorrectedAccRawValuesFromFifo(){
 
 xyzFloat MPU6500_WE::getGValuesFromFifo(){
     xyzFloat accRawVal = getCorrectedAccRawValuesFromFifo();
-    return xyzFloat{static_cast<float>(accRawVal.x * accRangeFactor / 16384.0),
-                    static_cast<float>(accRawVal.y * accRangeFactor / 16384.0),
-                    static_cast<float>(accRawVal.z * accRangeFactor / 16384.0)};
+    return accRawVal * (static_cast<float>(accRangeFactor) / 16384.0f);
 }
 
 
@@ -337,17 +376,13 @@ xyzFloat MPU6500_WE::getCorrectedGyrRawValues(){
 
 xyzFloat MPU6500_WE::getGyrValues(){
     xyzFloat const gyroValues = getCorrectedGyrRawValues();
-    return xyzFloat{static_cast<float>(gyroValues.x * gyrRangeFactor * 250. / 32768.0),
-                    static_cast<float>(gyroValues.y * gyrRangeFactor * 250. / 32768.0),
-                    static_cast<float>(gyroValues.z * gyrRangeFactor * 250. / 32768.0)};
+    return gyroValues * (static_cast<float>(gyrRangeFactor) * 250.f / 32768.0f);
 }
 
 xyzFloat MPU6500_WE::getGyrValuesFromFifo(){
     xyzFloat gyroValues = readMPU9250xyzValFromFifo();
     correctGyrRawValues(gyroValues);
-    return xyzFloat{static_cast<float>(gyroValues.x * gyrRangeFactor * 250. / 32768.0),
-                    static_cast<float>(gyroValues.y * gyrRangeFactor * 250. / 32768.0),
-                    static_cast<float>(gyroValues.z * gyrRangeFactor * 250. / 32768.0)};
+    return gyroValues * (static_cast<float>(gyrRangeFactor) * 250.f / 32768.0f);
 }
 
 /********* Power, Sleep, Standby *********/

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -1,0 +1,39 @@
+/********************************************************************
+* This is a library for the 6-axis gyroscope and accelerometer MPU6500.
+*********************************************************************/
+
+#include "MPU6500_WE.h"
+
+static uint8_t constexpr MPU6500_WHO_AM_I_CODE = 0x70;
+
+/************  Constructors ************/
+
+MPU6500_WE::MPU6500_WE(int const addr)
+    : MPU9250_WE(addr)
+{
+}
+
+MPU6500_WE::MPU6500_WE()
+    : MPU9250_WE()
+{
+}
+
+MPU6500_WE::MPU6500_WE(TwoWire * const w, int const addr)
+    : MPU9250_WE(w, addr)
+{
+}
+
+MPU6500_WE::MPU6500_WE(TwoWire * const w)
+    : MPU9250_WE(w)
+{
+}
+
+
+/************ Basic Settings ************/
+
+
+bool MPU6500_WE::init(){
+    return MPU9250_WE::init(MPU6500_WHO_AM_I_CODE);
+}
+
+/************ end ************/

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -342,7 +342,7 @@ void MPU6500_WE::enableGyrAxes(MPU9250_xyzEn enable){
 /************* x,y,z results *************/
 
 xyzFloat MPU6500_WE::getAccRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(REGISTER_ACCEL_OUT);
+    uint64_t const xyzDataReg = readMPU9250Register3x16(REGISTER_ACCEL_OUT);
     int16_t const xRaw = static_cast<int16_t>((xyzDataReg >> 32) & 0xFFFF);
     int16_t const yRaw = static_cast<int16_t>((xyzDataReg >> 16) & 0xFFFF);
     int16_t const zRaw = static_cast<int16_t>(xyzDataReg & 0xFFFF);

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -32,25 +32,12 @@ MPU6500_WE::MPU6500_WE(int addr)
     // intentionally empty
 }
 
-MPU6500_WE::MPU6500_WE()
-    : MPU6500_WE(&Wire, 0x68)
-{
-    // intentionally empty
-}
-
 MPU6500_WE::MPU6500_WE(TwoWire *w, int addr)
     : _wire(w)
     , i2cAddress(addr)
 {
     // intentionally empty
 }
-
-MPU6500_WE::MPU6500_WE(TwoWire *w)
-    : MPU6500_WE(w, 0x68)
-{
-    // intentionally empty
-}
-
 
 /************ Basic Settings ************/
 

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -26,24 +26,29 @@
 
 /************  Constructors ************/
 
-MPU6500_WE::MPU6500_WE(int addr){
-    _wire = &Wire;
-    i2cAddress = addr;
+MPU6500_WE::MPU6500_WE(int addr)
+    : MPU6500_WE(&Wire, addr)
+{
+    // intentionally empty
 }
 
-MPU6500_WE::MPU6500_WE(){
-    _wire = &Wire;
-    i2cAddress = 0x68;
+MPU6500_WE::MPU6500_WE()
+    : MPU6500_WE(&Wire, 0x68)
+{
+    // intentionally empty
 }
 
-MPU6500_WE::MPU6500_WE(TwoWire *w, int addr){
-    _wire = w;
-    i2cAddress = addr;
+MPU6500_WE::MPU6500_WE(TwoWire *w, int addr)
+    : _wire(w)
+    , i2cAddress(addr)
+{
+    // intentionally empty
 }
 
-MPU6500_WE::MPU6500_WE(TwoWire *w){
-    _wire = w;
-    i2cAddress = 0x68;
+MPU6500_WE::MPU6500_WE(TwoWire *w)
+    : MPU6500_WE(w, 0x68)
+{
+    // intentionally empty
 }
 
 

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -142,7 +142,7 @@ void MPU6500_WE::setGyrOffsets(float xOffset, float yOffset, float zOffset){
 }
 
 void MPU6500_WE::setGyrDLPF(MPU9250_dlpf dlpf){
-    regVal = readMPU9250Register8(MPU6500_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_CONFIG);
     regVal &= 0xF8;
     regVal |= dlpf;
     writeMPU9250Register(MPU6500_CONFIG, regVal);
@@ -153,7 +153,7 @@ void MPU6500_WE::setSampleRateDivider(uint8_t splRateDiv){
 }
 
 void MPU6500_WE::setGyrRange(MPU9250_gyroRange gyroRange){
-    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
     regVal &= 0xE7;
     regVal |= (gyroRange<<3);
     writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
@@ -161,20 +161,20 @@ void MPU6500_WE::setGyrRange(MPU9250_gyroRange gyroRange){
 }
 
 void MPU6500_WE::enableGyrDLPF(){
-    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
     regVal &= 0xFC;
     writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
 }
 
 void MPU6500_WE::disableGyrDLPF(MPU9250_bw_wo_dlpf bw){
-    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
     regVal &= 0xFC;
     regVal |= bw;
     writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
 }
 
 void MPU6500_WE::setAccRange(MPU9250_accRange accRange){
-    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG);
     regVal &= 0xE7;
     regVal |= (accRange<<3);
     writeMPU9250Register(MPU6500_ACCEL_CONFIG, regVal);
@@ -182,7 +182,7 @@ void MPU6500_WE::setAccRange(MPU9250_accRange accRange){
 }
 
 void MPU6500_WE::enableAccDLPF(bool enable){
-    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
     if(enable){
         regVal &= ~8;
     }
@@ -193,7 +193,7 @@ void MPU6500_WE::enableAccDLPF(bool enable){
 }
 
 void MPU6500_WE::setAccDLPF(MPU9250_dlpf dlpf){
-    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
     regVal &= 0xF8;
     regVal |= dlpf;
     writeMPU9250Register(MPU6500_ACCEL_CONFIG_2, regVal);
@@ -204,14 +204,14 @@ void MPU6500_WE::setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr){
 }
 
 void MPU6500_WE::enableAccAxes(MPU9250_xyzEn enable){
-    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
     regVal &= ~(0x38);
     regVal |= (enable<<3);
     writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
 }
 
 void MPU6500_WE::enableGyrAxes(MPU9250_xyzEn enable){
-    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
     regVal &= ~(0x07);
     regVal |= enable;
     writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
@@ -349,7 +349,7 @@ xyzFloat MPU6500_WE::getGyrValuesFromFifo(){
 /********* Power, Sleep, Standby *********/
 
 void MPU6500_WE::sleep(bool sleep){
-    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
     if(sleep){
         regVal |= 0x40;
     }
@@ -360,7 +360,7 @@ void MPU6500_WE::sleep(bool sleep){
 }
 
 void MPU6500_WE::enableCycle(bool cycle){
-    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
     if(cycle){
         regVal |= 0x20;
     }
@@ -371,7 +371,7 @@ void MPU6500_WE::enableCycle(bool cycle){
 }
 
 void MPU6500_WE::enableGyrStandby(bool gyroStandby){
-    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
     if(gyroStandby){
         regVal |= 0x10;
     }
@@ -476,7 +476,7 @@ float MPU6500_WE::getRoll(){
 /************** Interrupts ***************/
 
 void MPU6500_WE::setIntPinPolarity(MPU9250_intPinPol pol){
-    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
     if(pol){
         regVal |= 0x80;
     }
@@ -487,7 +487,7 @@ void MPU6500_WE::setIntPinPolarity(MPU9250_intPinPol pol){
 }
 
 void MPU6500_WE::enableIntLatch(bool latch){
-    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
     if(latch){
         regVal |= 0x20;
     }
@@ -498,7 +498,7 @@ void MPU6500_WE::enableIntLatch(bool latch){
 }
 
 void MPU6500_WE::enableClearIntByAnyRead(bool clearByAnyRead){
-    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
     if(clearByAnyRead){
         regVal |= 0x10;
     }
@@ -509,13 +509,13 @@ void MPU6500_WE::enableClearIntByAnyRead(bool clearByAnyRead){
 }
 
 void MPU6500_WE::enableInterrupt(MPU9250_intType intType){
-    regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
     regVal |= intType;
     writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
 }
 
 void MPU6500_WE::disableInterrupt(MPU9250_intType intType){
-    regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
     regVal &= ~intType;
     writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
 }
@@ -526,7 +526,7 @@ bool MPU6500_WE::checkInterrupt(uint8_t source, MPU9250_intType type){
 }
 
 uint8_t MPU6500_WE::readAndClearInterrupts(){
-    regVal = readMPU9250Register8(MPU6500_INT_STATUS);
+    uint8_t regVal = readMPU9250Register8(MPU6500_INT_STATUS);
     return regVal;
 }
 
@@ -535,7 +535,7 @@ void MPU6500_WE::setWakeOnMotionThreshold(uint8_t womthresh){
 }
 
 void MPU6500_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn){
-    regVal = 0;
+    uint8_t regVal = 0;
     if(womEn){
         regVal |= 0x80;
     }
@@ -563,7 +563,7 @@ void MPU6500_WE::stopFifo(){
 }
 
 void MPU6500_WE::enableFifo(bool fifo){
-    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
     if(fifo){
         regVal |= 0x40;
     }
@@ -574,7 +574,7 @@ void MPU6500_WE::enableFifo(bool fifo){
 }
 
 void MPU6500_WE::resetFifo(){
-    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
     regVal |= 0x04;
     writeMPU9250Register(MPU6500_USER_CTRL, regVal);
 }
@@ -585,7 +585,7 @@ int16_t MPU6500_WE::getFifoCount(){
 }
 
 void MPU6500_WE::setFifoMode(MPU9250_fifoMode mode){
-    regVal = readMPU9250Register8(MPU6500_CONFIG);
+    uint8_t regVal = readMPU9250Register8(MPU6500_CONFIG);
     if(mode){
         regVal |= 0x40;
     }
@@ -650,7 +650,7 @@ void MPU6500_WE::reset_MPU9250(){
 }
 
 void MPU6500_WE::enableI2CMaster(){
-    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
     regVal |= MPU6500_I2C_MST_EN;
     writeMPU9250Register(MPU6500_USER_CTRL, regVal); //enable I2C master
     writeMPU9250Register(MPU6500_I2C_MST_CTRL, 0x00); // set I2C clock to 400 kHz

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -79,6 +79,39 @@ xyzFloat xyzFloat::operator/(float const divisor) const
                     z / divisor};
 }
 
+xyzFloat & xyzFloat::operator+=(xyzFloat const & summand)
+{
+    x += summand.x;
+    y += summand.y;
+    z += summand.z;
+    return *this;
+}
+
+xyzFloat & xyzFloat::operator-=(xyzFloat const & subtrahend)
+{
+    x -= subtrahend.x;
+    y -= subtrahend.y;
+    z -= subtrahend.z;
+    return *this;
+}
+
+xyzFloat & xyzFloat::operator*=(float const operand)
+{
+    x *= operand;
+    y *= operand;
+    z *= operand;
+    return *this;
+}
+
+xyzFloat & xyzFloat::operator/=(float const divisor)
+{
+    x /= divisor;
+    y /= divisor;
+    z /= divisor;
+    return *this;
+}
+
+
 
 /* Registers MPU6500 */
 uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_X_GYRO     ;

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -24,6 +24,67 @@
 
 #include "MPU6500_WE.h"
 
+/* Registers MPU6500 */
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_X_GYRO     ;
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_Y_GYRO     ;
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_Z_GYRO     ;
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_X_ACCEL    ;
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_Y_ACCEL    ;
+uint8_t constexpr MPU6500_WE::REGISTER_SELF_TEST_Z_ACCEL    ;
+uint8_t constexpr MPU6500_WE::REGISTER_XG_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_XG_OFFSET_L          ;
+uint8_t constexpr MPU6500_WE::REGISTER_YG_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_YG_OFFSET_L          ;
+uint8_t constexpr MPU6500_WE::REGISTER_ZG_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_ZG_OFFSET_L          ;
+uint8_t constexpr MPU6500_WE::REGISTER_SMPLRT_DIV           ;
+uint8_t constexpr MPU6500_WE::REGISTER_CONFIG               ;
+uint8_t constexpr MPU6500_WE::REGISTER_GYRO_CONFIG          ;
+uint8_t constexpr MPU6500_WE::REGISTER_ACCEL_CONFIG         ;
+uint8_t constexpr MPU6500_WE::REGISTER_ACCEL_CONFIG_2       ;
+uint8_t constexpr MPU6500_WE::REGISTER_LP_ACCEL_ODR         ;
+uint8_t constexpr MPU6500_WE::REGISTER_WOM_THR              ;
+uint8_t constexpr MPU6500_WE::REGISTER_FIFO_EN              ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_MST_CTRL         ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_SLV0_ADDR        ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_SLV0_REG         ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_SLV0_CTRL        ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_MST_STATUS       ;
+uint8_t constexpr MPU6500_WE::REGISTER_INT_PIN_CFG          ;
+uint8_t constexpr MPU6500_WE::REGISTER_INT_ENABLE           ;
+uint8_t constexpr MPU6500_WE::REGISTER_INT_STATUS           ;
+uint8_t constexpr MPU6500_WE::REGISTER_ACCEL_OUT            ;
+uint8_t constexpr MPU6500_WE::REGISTER_TEMP_OUT             ;
+uint8_t constexpr MPU6500_WE::REGISTER_GYRO_OUT             ;
+uint8_t constexpr MPU6500_WE::REGISTER_EXT_SLV_SENS_DATA_00 ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_SLV0_DO          ;
+uint8_t constexpr MPU6500_WE::REGISTER_I2C_MST_DELAY_CTRL   ;
+uint8_t constexpr MPU6500_WE::REGISTER_SIGNAL_PATH_RESET    ;
+uint8_t constexpr MPU6500_WE::REGISTER_MOT_DET_CTRL         ;
+uint8_t constexpr MPU6500_WE::REGISTER_USER_CTRL            ;
+uint8_t constexpr MPU6500_WE::REGISTER_PWR_MGMT_1           ;
+uint8_t constexpr MPU6500_WE::REGISTER_PWR_MGMT_2           ;
+uint8_t constexpr MPU6500_WE::REGISTER_FIFO_COUNT           ;
+uint8_t constexpr MPU6500_WE::REGISTER_FIFO_R_W             ;
+uint8_t constexpr MPU6500_WE::REGISTER_WHO_AM_I             ;
+uint8_t constexpr MPU6500_WE::REGISTER_XA_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_XA_OFFSET_L          ;
+uint8_t constexpr MPU6500_WE::REGISTER_YA_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_YA_OFFSET_L          ;
+uint8_t constexpr MPU6500_WE::REGISTER_ZA_OFFSET_H          ;
+uint8_t constexpr MPU6500_WE::REGISTER_ZA_OFFSET_L          ;
+
+/* Register Values */
+uint8_t constexpr MPU6500_WE::REGISTER_VALUE_RESET          ;
+uint8_t constexpr MPU6500_WE::REGISTER_VALUE_BYPASS_EN      ;
+uint8_t constexpr MPU6500_WE::REGISTER_VALUE_I2C_MST_EN     ;
+uint8_t constexpr MPU6500_WE::REGISTER_VALUE_CLK_SEL_PLL    ;
+
+/* Others */
+float constexpr MPU6500_WE::ROOM_TEMPERATURE_OFFSET         ;
+float constexpr MPU6500_WE::TEMPERATURE_SENSITIVITY         ;
+float constexpr MPU6500_WE::WHO_AM_I_CODE                   ;
+
 /************  Constructors ************/
 
 MPU6500_WE::MPU6500_WE(int addr)
@@ -44,7 +105,7 @@ MPU6500_WE::MPU6500_WE(TwoWire *w, int addr)
 bool MPU6500_WE::init(uint8_t const expectedValue){
     reset_MPU9250();
     delay(10);
-    writeMPU9250Register(MPU6500_INT_PIN_CFG, MPU6500_BYPASS_EN);  // Bypass Enable
+    writeMPU9250Register(REGISTER_INT_PIN_CFG, REGISTER_VALUE_BYPASS_EN);  // Bypass Enable
     delay(10);
     if(whoAmI() != expectedValue){
         return false;
@@ -66,11 +127,11 @@ bool MPU6500_WE::init(uint8_t const expectedValue){
 
 
 bool MPU6500_WE::init(){
-    return init(MPU6500_WHO_AM_I_CODE);
+    return init(WHO_AM_I_CODE);
 }
 
 uint8_t MPU6500_WE::whoAmI(){
-    return readMPU9250Register8(MPU6500_WHO_AM_I);
+    return readMPU9250Register8(REGISTER_WHO_AM_I);
 }
 
 void MPU6500_WE::autoOffsets(){
@@ -129,85 +190,85 @@ void MPU6500_WE::setGyrOffsets(float xOffset, float yOffset, float zOffset){
 }
 
 void MPU6500_WE::setGyrDLPF(MPU9250_dlpf dlpf){
-    uint8_t regVal = readMPU9250Register8(MPU6500_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_CONFIG);
     regVal &= 0xF8;
     regVal |= dlpf;
-    writeMPU9250Register(MPU6500_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_CONFIG, regVal);
 }
 
 void MPU6500_WE::setSampleRateDivider(uint8_t splRateDiv){
-    writeMPU9250Register(MPU6500_SMPLRT_DIV, splRateDiv);
+    writeMPU9250Register(REGISTER_SMPLRT_DIV, splRateDiv);
 }
 
 void MPU6500_WE::setGyrRange(MPU9250_gyroRange gyroRange){
-    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_GYRO_CONFIG);
     regVal &= 0xE7;
     regVal |= (gyroRange<<3);
-    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_GYRO_CONFIG, regVal);
     gyrRangeFactor = (1<<gyroRange);
 }
 
 void MPU6500_WE::enableGyrDLPF(){
-    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_GYRO_CONFIG);
     regVal &= 0xFC;
-    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_GYRO_CONFIG, regVal);
 }
 
 void MPU6500_WE::disableGyrDLPF(MPU9250_bw_wo_dlpf bw){
-    uint8_t regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_GYRO_CONFIG);
     regVal &= 0xFC;
     regVal |= bw;
-    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_GYRO_CONFIG, regVal);
 }
 
 void MPU6500_WE::setAccRange(MPU9250_accRange accRange){
-    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_ACCEL_CONFIG);
     regVal &= 0xE7;
     regVal |= (accRange<<3);
-    writeMPU9250Register(MPU6500_ACCEL_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_ACCEL_CONFIG, regVal);
     accRangeFactor = 1<<accRange;
 }
 
 void MPU6500_WE::enableAccDLPF(bool enable){
-    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    uint8_t regVal = readMPU9250Register8(REGISTER_ACCEL_CONFIG_2);
     if(enable){
         regVal &= ~8;
     }
     else{
         regVal |= 8;
     }
-    writeMPU9250Register(MPU6500_ACCEL_CONFIG_2, regVal);
+    writeMPU9250Register(REGISTER_ACCEL_CONFIG_2, regVal);
 }
 
 void MPU6500_WE::setAccDLPF(MPU9250_dlpf dlpf){
-    uint8_t regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    uint8_t regVal = readMPU9250Register8(REGISTER_ACCEL_CONFIG_2);
     regVal &= 0xF8;
     regVal |= dlpf;
-    writeMPU9250Register(MPU6500_ACCEL_CONFIG_2, regVal);
+    writeMPU9250Register(REGISTER_ACCEL_CONFIG_2, regVal);
 }
 
 void MPU6500_WE::setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr){
-    writeMPU9250Register(MPU6500_LP_ACCEL_ODR, lpaodr);
+    writeMPU9250Register(REGISTER_LP_ACCEL_ODR, lpaodr);
 }
 
 void MPU6500_WE::enableAccAxes(MPU9250_xyzEn enable){
-    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    uint8_t regVal = readMPU9250Register8(REGISTER_PWR_MGMT_2);
     regVal &= ~(0x38);
     regVal |= (enable<<3);
-    writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
+    writeMPU9250Register(REGISTER_PWR_MGMT_2, regVal);
 }
 
 void MPU6500_WE::enableGyrAxes(MPU9250_xyzEn enable){
-    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    uint8_t regVal = readMPU9250Register8(REGISTER_PWR_MGMT_2);
     regVal &= ~(0x07);
     regVal |= enable;
-    writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
+    writeMPU9250Register(REGISTER_PWR_MGMT_2, regVal);
 }
 
 /************* x,y,z results *************/
 
 xyzFloat MPU6500_WE::getAccRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_ACCEL_OUT);
+    uint64_t xyzDataReg = readMPU9250Register3x16(REGISTER_ACCEL_OUT);
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
@@ -220,7 +281,7 @@ xyzFloat MPU6500_WE::getAccRawValues(){
 }
 
 xyzFloat MPU6500_WE::getCorrectedAccRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_ACCEL_OUT);
+    uint64_t xyzDataReg = readMPU9250Register3x16(REGISTER_ACCEL_OUT);
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
@@ -277,13 +338,13 @@ float MPU6500_WE::getResultantG(xyzFloat gVal){
 }
 
 float MPU6500_WE::getTemperature(){
-    int16_t regVal16 = readMPU9250Register16(MPU6500_TEMP_OUT);
-    float tmp = (regVal16*1.0 - MPU6500_ROOM_TEMP_OFFSET)/MPU6500_T_SENSITIVITY + 21.0;
+    int16_t regVal16 = readMPU9250Register16(REGISTER_TEMP_OUT);
+    float tmp = (regVal16*1.0 - ROOM_TEMPERATURE_OFFSET)/TEMPERATURE_SENSITIVITY + 21.0;
     return tmp;
 }
 
 xyzFloat MPU6500_WE::getGyrRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_GYRO_OUT);
+    uint64_t xyzDataReg = readMPU9250Register3x16(REGISTER_GYRO_OUT);
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
@@ -296,7 +357,7 @@ xyzFloat MPU6500_WE::getGyrRawValues(){
 }
 
 xyzFloat MPU6500_WE::getCorrectedGyrRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_GYRO_OUT);
+    uint64_t xyzDataReg = readMPU9250Register3x16(REGISTER_GYRO_OUT);
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
@@ -336,36 +397,36 @@ xyzFloat MPU6500_WE::getGyrValuesFromFifo(){
 /********* Power, Sleep, Standby *********/
 
 void MPU6500_WE::sleep(bool sleep){
-    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(REGISTER_PWR_MGMT_1);
     if(sleep){
         regVal |= 0x40;
     }
     else{
         regVal &= ~(0x40);
     }
-    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+    writeMPU9250Register(REGISTER_PWR_MGMT_1, regVal);
 }
 
 void MPU6500_WE::enableCycle(bool cycle){
-    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(REGISTER_PWR_MGMT_1);
     if(cycle){
         regVal |= 0x20;
     }
     else{
         regVal &= ~(0x20);
     }
-    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+    writeMPU9250Register(REGISTER_PWR_MGMT_1, regVal);
 }
 
 void MPU6500_WE::enableGyrStandby(bool gyroStandby){
-    uint8_t regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    uint8_t regVal = readMPU9250Register8(REGISTER_PWR_MGMT_1);
     if(gyroStandby){
         regVal |= 0x10;
     }
     else{
         regVal &= ~(0x10);
     }
-    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+    writeMPU9250Register(REGISTER_PWR_MGMT_1, regVal);
 }
 
 
@@ -463,48 +524,48 @@ float MPU6500_WE::getRoll(){
 /************** Interrupts ***************/
 
 void MPU6500_WE::setIntPinPolarity(MPU9250_intPinPol pol){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_PIN_CFG);
     if(pol){
         regVal |= 0x80;
     }
     else{
         regVal &= ~(0x80);
     }
-    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+    writeMPU9250Register(REGISTER_INT_PIN_CFG, regVal);
 }
 
 void MPU6500_WE::enableIntLatch(bool latch){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_PIN_CFG);
     if(latch){
         regVal |= 0x20;
     }
     else{
         regVal &= ~(0x20);
     }
-    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+    writeMPU9250Register(REGISTER_INT_PIN_CFG, regVal);
 }
 
 void MPU6500_WE::enableClearIntByAnyRead(bool clearByAnyRead){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_PIN_CFG);
     if(clearByAnyRead){
         regVal |= 0x10;
     }
     else{
         regVal &= ~(0x10);
     }
-    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+    writeMPU9250Register(REGISTER_INT_PIN_CFG, regVal);
 }
 
 void MPU6500_WE::enableInterrupt(MPU9250_intType intType){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_ENABLE);
     regVal |= intType;
-    writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
+    writeMPU9250Register(REGISTER_INT_ENABLE, regVal);
 }
 
 void MPU6500_WE::disableInterrupt(MPU9250_intType intType){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_ENABLE);
     regVal &= ~intType;
-    writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
+    writeMPU9250Register(REGISTER_INT_ENABLE, regVal);
 }
 
 bool MPU6500_WE::checkInterrupt(uint8_t source, MPU9250_intType type){
@@ -513,12 +574,12 @@ bool MPU6500_WE::checkInterrupt(uint8_t source, MPU9250_intType type){
 }
 
 uint8_t MPU6500_WE::readAndClearInterrupts(){
-    uint8_t regVal = readMPU9250Register8(MPU6500_INT_STATUS);
+    uint8_t regVal = readMPU9250Register8(REGISTER_INT_STATUS);
     return regVal;
 }
 
 void MPU6500_WE::setWakeOnMotionThreshold(uint8_t womthresh){
-    writeMPU9250Register(MPU6500_WOM_THR, womthresh);
+    writeMPU9250Register(REGISTER_WOM_THR, womthresh);
 }
 
 void MPU6500_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn){
@@ -529,7 +590,7 @@ void MPU6500_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCo
     if(womCompEn){
         regVal |= 0x40;
     }
-    writeMPU9250Register(MPU6500_MOT_DET_CTRL, regVal);
+    writeMPU9250Register(REGISTER_MOT_DET_CTRL, regVal);
 }
 
 /***************** FIFO ******************/
@@ -542,44 +603,44 @@ void MPU6500_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCo
  */
 void MPU6500_WE::startFifo(MPU9250_fifo_type fifo){
     fifoType = fifo;
-    writeMPU9250Register(MPU6500_FIFO_EN, fifoType);
+    writeMPU9250Register(REGISTER_FIFO_EN, fifoType);
 }
 
 void MPU6500_WE::stopFifo(){
-    writeMPU9250Register(MPU6500_FIFO_EN, 0);
+    writeMPU9250Register(REGISTER_FIFO_EN, 0);
 }
 
 void MPU6500_WE::enableFifo(bool fifo){
-    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    uint8_t regVal = readMPU9250Register8(REGISTER_USER_CTRL);
     if(fifo){
         regVal |= 0x40;
     }
     else{
         regVal &= ~(0x40);
     }
-    writeMPU9250Register(MPU6500_USER_CTRL, regVal);
+    writeMPU9250Register(REGISTER_USER_CTRL, regVal);
 }
 
 void MPU6500_WE::resetFifo(){
-    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    uint8_t regVal = readMPU9250Register8(REGISTER_USER_CTRL);
     regVal |= 0x04;
-    writeMPU9250Register(MPU6500_USER_CTRL, regVal);
+    writeMPU9250Register(REGISTER_USER_CTRL, regVal);
 }
 
 int16_t MPU6500_WE::getFifoCount(){
-    uint16_t regVal16 = (uint16_t) readMPU9250Register16(MPU6500_FIFO_COUNT);
+    uint16_t regVal16 = (uint16_t) readMPU9250Register16(REGISTER_FIFO_COUNT);
     return regVal16;
 }
 
 void MPU6500_WE::setFifoMode(MPU9250_fifoMode mode){
-    uint8_t regVal = readMPU9250Register8(MPU6500_CONFIG);
+    uint8_t regVal = readMPU9250Register8(REGISTER_CONFIG);
     if(mode){
         regVal |= 0x40;
     }
     else{
         regVal &= ~(0x40);
     }
-    writeMPU9250Register(MPU6500_CONFIG, regVal);
+    writeMPU9250Register(REGISTER_CONFIG, regVal);
 
 }
 
@@ -602,14 +663,14 @@ void MPU6500_WE::findFifoBegin(){
     if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
         if(count > 510){
             for(int i=0; i<2; i++){
-                readMPU9250Register8(MPU6500_FIFO_R_W);
+                readMPU9250Register8(REGISTER_FIFO_R_W);
             }
         }
     }
     else if(fifoType==MPU9250_FIFO_ACC_GYR){
         if(count > 504){
             for(int i=0; i<8; i++){
-                readMPU9250Register8(MPU6500_FIFO_R_W);
+                readMPU9250Register8(REGISTER_FIFO_R_W);
             }
         }
     }
@@ -632,15 +693,15 @@ void MPU6500_WE::correctGyrRawValues(){
 }
 
 void MPU6500_WE::reset_MPU9250(){
-    writeMPU9250Register(MPU6500_PWR_MGMT_1, MPU6500_RESET);
+    writeMPU9250Register(REGISTER_PWR_MGMT_1, REGISTER_VALUE_RESET);
     delay(10);  // wait for registers to reset
 }
 
 void MPU6500_WE::enableI2CMaster(){
-    uint8_t regVal = readMPU9250Register8(MPU6500_USER_CTRL);
-    regVal |= MPU6500_I2C_MST_EN;
-    writeMPU9250Register(MPU6500_USER_CTRL, regVal); //enable I2C master
-    writeMPU9250Register(MPU6500_I2C_MST_CTRL, 0x00); // set I2C clock to 400 kHz
+    uint8_t regVal = readMPU9250Register8(REGISTER_USER_CTRL);
+    regVal |= REGISTER_VALUE_I2C_MST_EN;
+    writeMPU9250Register(REGISTER_USER_CTRL, regVal); //enable I2C master
+    writeMPU9250Register(REGISTER_I2C_MST_CTRL, 0x00); // set I2C clock to 400 kHz
     delay(10);
 }
 
@@ -702,7 +763,7 @@ xyzFloat MPU6500_WE::readMPU9250xyzValFromFifo(){
     xyzFloat xyzResult = {0.0, 0.0, 0.0};
 
     _wire->beginTransmission(i2cAddress);
-    _wire->write(MPU6500_FIFO_R_W);
+    _wire->write(REGISTER_FIFO_R_W);
     _wire->endTransmission(false);
     _wire->requestFrom(i2cAddress,6);
     if(_wire->available()){

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -782,7 +782,6 @@ uint64_t MPU6500_WE::readMPU9250Register3x16(uint8_t reg){
 
 xyzFloat MPU6500_WE::readMPU9250xyzValFromFifo(){
     uint8_t fifoTriple[6];
-    xyzFloat xyzResult = {0.0, 0.0, 0.0};
 
     _wire->beginTransmission(i2cAddress);
     _wire->write(REGISTER_FIFO_R_W);
@@ -794,9 +793,10 @@ xyzFloat MPU6500_WE::readMPU9250xyzValFromFifo(){
         }
     }
 
-    xyzResult.x = ((int16_t)((fifoTriple[0]<<8) + fifoTriple[1])) * 1.0;
-    xyzResult.y = ((int16_t)((fifoTriple[2]<<8) + fifoTriple[3])) * 1.0;
-    xyzResult.z = ((int16_t)((fifoTriple[4]<<8) + fifoTriple[5])) * 1.0;
+    xyzFloat xyzResult = {0.0, 0.0, 0.0};
+    xyzResult.x = static_cast<float>((int16_t)((fifoTriple[0]<<8) + fifoTriple[1]));
+    xyzResult.y = static_cast<float>((int16_t)((fifoTriple[2]<<8) + fifoTriple[3]));
+    xyzResult.z = static_cast<float>((int16_t)((fifoTriple[4]<<8) + fifoTriple[5]));
 
     return xyzResult;
 }

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -3,37 +3,727 @@
 *********************************************************************/
 
 #include "MPU6500_WE.h"
+/********************************************************************
+* This is a library for the 6-axis gyroscope and accelerometer MPU6500.
+*
+* You'll find an example which should enable you to use the library.
+*
+* You are free to use it, change it or build on it. In case you like
+* it, it would be cool if you give it a star.
+*
+* If you find bugs, please inform me!
+*
+* Written by Wolfgang (Wolle) Ewald
+*
+* For further information visit my blog:
+*
+* https://wolles-elektronikkiste.de/mpu9250-9-achsen-sensormodul-teil-1  (German)
+* https://wolles-elektronikkiste.de/en/mpu9250-9-axis-sensor-module-part-1  (English)
+*
+*********************************************************************/
 
-static uint8_t constexpr MPU6500_WHO_AM_I_CODE = 0x70;
+#include "MPU6500_WE.h"
 
 /************  Constructors ************/
 
-MPU6500_WE::MPU6500_WE(int const addr)
-    : MPU9250_WE(addr)
-{
+MPU6500_WE::MPU6500_WE(int addr){
+    _wire = &Wire;
+    i2cAddress = addr;
 }
 
-MPU6500_WE::MPU6500_WE()
-    : MPU9250_WE()
-{
+MPU6500_WE::MPU6500_WE(){
+    _wire = &Wire;
+    i2cAddress = 0x68;
 }
 
-MPU6500_WE::MPU6500_WE(TwoWire * const w, int const addr)
-    : MPU9250_WE(w, addr)
-{
+MPU6500_WE::MPU6500_WE(TwoWire *w, int addr){
+    _wire = w;
+    i2cAddress = addr;
 }
 
-MPU6500_WE::MPU6500_WE(TwoWire * const w)
-    : MPU9250_WE(w)
-{
+MPU6500_WE::MPU6500_WE(TwoWire *w){
+    _wire = w;
+    i2cAddress = 0x68;
 }
 
 
 /************ Basic Settings ************/
 
+bool MPU6500_WE::init(uint8_t const expectedValue){
+    reset_MPU9250();
+    delay(10);
+    writeMPU9250Register(MPU6500_INT_PIN_CFG, MPU6500_BYPASS_EN);  // Bypass Enable
+    delay(10);
+    if(whoAmI() != expectedValue){
+        return false;
+    }
+
+    accOffsetVal.x = 0.0;
+    accOffsetVal.y = 0.0;
+    accOffsetVal.z = 0.0;
+    accRangeFactor = 1;
+    gyrOffsetVal.x = 0.0;
+    gyrOffsetVal.y = 0.0;
+    gyrOffsetVal.z = 0.0;
+    gyrRangeFactor = 1;
+    fifoType = MPU9250_FIFO_ACC;
+    sleep(false);
+
+    return true;
+}
+
 
 bool MPU6500_WE::init(){
-    return MPU9250_WE::init(MPU6500_WHO_AM_I_CODE);
+    return init(MPU6500_WHO_AM_I_CODE);
+}
+
+uint8_t MPU6500_WE::whoAmI(){
+    return readMPU9250Register8(MPU6500_WHO_AM_I);
+}
+
+void MPU6500_WE::autoOffsets(){
+    accOffsetVal.x = 0.0;
+    accOffsetVal.y = 0.0;
+    accOffsetVal.z = 0.0;
+
+    gyrOffsetVal.x = 0.0;
+    gyrOffsetVal.y = 0.0;
+    gyrOffsetVal.z = 0.0;
+
+    enableGyrDLPF();
+    setGyrDLPF(MPU9250_DLPF_6);  // lowest noise
+    setGyrRange(MPU9250_GYRO_RANGE_250); // highest resolution
+    setAccRange(MPU9250_ACC_RANGE_2G);
+    enableAccDLPF(true);
+    setAccDLPF(MPU9250_DLPF_6);
+    delay(100);
+
+    for(int i=0; i<50; i++){
+        // acceleration
+        getAccRawValues();
+        accOffsetVal.x += accRawVal.x;
+        accOffsetVal.y += accRawVal.y;
+        accOffsetVal.z += accRawVal.z;
+        // gyro
+        getGyrRawValues();
+        gyrOffsetVal.x += gyrRawVal.x;
+        gyrOffsetVal.y += gyrRawVal.y;
+        gyrOffsetVal.z += gyrRawVal.z;
+        delay(1);
+    }
+
+    // acceleration
+    accOffsetVal.x /= 50;
+    accOffsetVal.y /= 50;
+    accOffsetVal.z /= 50;
+    accOffsetVal.z -= 16384.0;
+    // gyro
+    gyrOffsetVal.x /= 50;
+    gyrOffsetVal.y /= 50;
+    gyrOffsetVal.z /= 50;
+
+}
+
+void MPU6500_WE::setAccOffsets(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax){
+    accOffsetVal.x = (xMax + xMin) * 0.5;
+    accOffsetVal.y = (yMax + yMin) * 0.5;
+    accOffsetVal.z = (zMax + zMin) * 0.5;
+}
+
+void MPU6500_WE::setGyrOffsets(float xOffset, float yOffset, float zOffset){
+    gyrOffsetVal.x = xOffset;
+    gyrOffsetVal.y = yOffset;
+    gyrOffsetVal.z = zOffset;
+}
+
+void MPU6500_WE::setGyrDLPF(MPU9250_dlpf dlpf){
+    regVal = readMPU9250Register8(MPU6500_CONFIG);
+    regVal &= 0xF8;
+    regVal |= dlpf;
+    writeMPU9250Register(MPU6500_CONFIG, regVal);
+}
+
+void MPU6500_WE::setSampleRateDivider(uint8_t splRateDiv){
+    writeMPU9250Register(MPU6500_SMPLRT_DIV, splRateDiv);
+}
+
+void MPU6500_WE::setGyrRange(MPU9250_gyroRange gyroRange){
+    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    regVal &= 0xE7;
+    regVal |= (gyroRange<<3);
+    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+    gyrRangeFactor = (1<<gyroRange);
+}
+
+void MPU6500_WE::enableGyrDLPF(){
+    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    regVal &= 0xFC;
+    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+}
+
+void MPU6500_WE::disableGyrDLPF(MPU9250_bw_wo_dlpf bw){
+    regVal = readMPU9250Register8(MPU6500_GYRO_CONFIG);
+    regVal &= 0xFC;
+    regVal |= bw;
+    writeMPU9250Register(MPU6500_GYRO_CONFIG, regVal);
+}
+
+void MPU6500_WE::setAccRange(MPU9250_accRange accRange){
+    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG);
+    regVal &= 0xE7;
+    regVal |= (accRange<<3);
+    writeMPU9250Register(MPU6500_ACCEL_CONFIG, regVal);
+    accRangeFactor = 1<<accRange;
+}
+
+void MPU6500_WE::enableAccDLPF(bool enable){
+    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    if(enable){
+        regVal &= ~8;
+    }
+    else{
+        regVal |= 8;
+    }
+    writeMPU9250Register(MPU6500_ACCEL_CONFIG_2, regVal);
+}
+
+void MPU6500_WE::setAccDLPF(MPU9250_dlpf dlpf){
+    regVal = readMPU9250Register8(MPU6500_ACCEL_CONFIG_2);
+    regVal &= 0xF8;
+    regVal |= dlpf;
+    writeMPU9250Register(MPU6500_ACCEL_CONFIG_2, regVal);
+}
+
+void MPU6500_WE::setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr){
+    writeMPU9250Register(MPU6500_LP_ACCEL_ODR, lpaodr);
+}
+
+void MPU6500_WE::enableAccAxes(MPU9250_xyzEn enable){
+    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    regVal &= ~(0x38);
+    regVal |= (enable<<3);
+    writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
+}
+
+void MPU6500_WE::enableGyrAxes(MPU9250_xyzEn enable){
+    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_2);
+    regVal &= ~(0x07);
+    regVal |= enable;
+    writeMPU9250Register(MPU6500_PWR_MGMT_2, regVal);
+}
+
+/************* x,y,z results *************/
+
+xyzFloat MPU6500_WE::getAccRawValues(){
+    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_ACCEL_OUT);
+    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
+    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
+    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
+
+    accRawVal.x = xRaw * 1.0;
+    accRawVal.y = yRaw * 1.0;
+    accRawVal.z = zRaw * 1.0;
+
+    return accRawVal;
+}
+
+xyzFloat MPU6500_WE::getCorrectedAccRawValues(){
+    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_ACCEL_OUT);
+    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
+    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
+    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
+
+    accRawVal.x = xRaw * 1.0;
+    accRawVal.y = yRaw * 1.0;
+    accRawVal.z = zRaw * 1.0;
+
+    correctAccRawValues();
+
+    return accRawVal;
+}
+
+xyzFloat MPU6500_WE::getGValues(){
+    xyzFloat gVal;
+    getCorrectedAccRawValues();
+
+    gVal.x = accRawVal.x * accRangeFactor / 16384.0;
+    gVal.y = accRawVal.y * accRangeFactor / 16384.0;
+    gVal.z = accRawVal.z * accRangeFactor / 16384.0;
+    return gVal;
+}
+
+xyzFloat MPU6500_WE::getAccRawValuesFromFifo(){
+    xyzFloat accRawVal = readMPU9250xyzValFromFifo();
+    return accRawVal;
+}
+
+xyzFloat MPU6500_WE::getCorrectedAccRawValuesFromFifo(){
+    accRawVal = getAccRawValuesFromFifo();
+
+    correctAccRawValues();
+
+    return accRawVal;
+}
+
+xyzFloat MPU6500_WE::getGValuesFromFifo(){
+    xyzFloat gVal;
+    getCorrectedAccRawValuesFromFifo();
+
+    gVal.x = accRawVal.x * accRangeFactor / 16384.0;
+    gVal.y = accRawVal.y * accRangeFactor / 16384.0;
+    gVal.z = accRawVal.z * accRangeFactor / 16384.0;
+    return gVal;
+}
+
+
+
+float MPU6500_WE::getResultantG(xyzFloat gVal){
+    float resultant = 0.0;
+    resultant = sqrt(sq(gVal.x) + sq(gVal.y) + sq(gVal.z));
+
+    return resultant;
+}
+
+float MPU6500_WE::getTemperature(){
+    int16_t regVal16 = readMPU9250Register16(MPU6500_TEMP_OUT);
+    float tmp = (regVal16*1.0 - MPU6500_ROOM_TEMP_OFFSET)/MPU6500_T_SENSITIVITY + 21.0;
+    return tmp;
+}
+
+xyzFloat MPU6500_WE::getGyrRawValues(){
+    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_GYRO_OUT);
+    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
+    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
+    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
+
+    gyrRawVal.x = xRaw * 1.0;
+    gyrRawVal.y = yRaw * 1.0;
+    gyrRawVal.z = zRaw * 1.0;
+
+    return gyrRawVal;
+}
+
+xyzFloat MPU6500_WE::getCorrectedGyrRawValues(){
+    uint64_t xyzDataReg = readMPU9250Register3x16(MPU6500_GYRO_OUT);
+    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
+    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
+    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
+
+    gyrRawVal.x = xRaw * 1.0;
+    gyrRawVal.y = yRaw * 1.0;
+    gyrRawVal.z = zRaw * 1.0;
+
+    correctGyrRawValues();
+
+    return gyrRawVal;
+}
+
+xyzFloat MPU6500_WE::getGyrValues(){
+    xyzFloat gyrVal;
+    getCorrectedGyrRawValues();
+
+    gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
+    gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
+    gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
+
+    return gyrVal;
+}
+
+xyzFloat MPU6500_WE::getGyrValuesFromFifo(){
+    xyzFloat gyrVal;
+    gyrRawVal = readMPU9250xyzValFromFifo();
+
+    correctGyrRawValues();
+    gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
+    gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
+    gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
+
+    return gyrVal;
+}
+
+/********* Power, Sleep, Standby *********/
+
+void MPU6500_WE::sleep(bool sleep){
+    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    if(sleep){
+        regVal |= 0x40;
+    }
+    else{
+        regVal &= ~(0x40);
+    }
+    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+}
+
+void MPU6500_WE::enableCycle(bool cycle){
+    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    if(cycle){
+        regVal |= 0x20;
+    }
+    else{
+        regVal &= ~(0x20);
+    }
+    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+}
+
+void MPU6500_WE::enableGyrStandby(bool gyroStandby){
+    regVal = readMPU9250Register8(MPU6500_PWR_MGMT_1);
+    if(gyroStandby){
+        regVal |= 0x10;
+    }
+    else{
+        regVal &= ~(0x10);
+    }
+    writeMPU9250Register(MPU6500_PWR_MGMT_1, regVal);
+}
+
+
+/******** Angles and Orientation *********/
+
+xyzFloat MPU6500_WE::getAngles(){
+    xyzFloat angleVal;
+    xyzFloat gVal = getGValues();
+    if(gVal.x > 1.0){
+        gVal.x = 1.0;
+    }
+    else if(gVal.x < -1.0){
+        gVal.x = -1.0;
+    }
+    angleVal.x = (asin(gVal.x)) * 57.296;
+
+    if(gVal.y > 1.0){
+        gVal.y = 1.0;
+    }
+    else if(gVal.y < -1.0){
+        gVal.y = -1.0;
+    }
+    angleVal.y = (asin(gVal.y)) * 57.296;
+
+    if(gVal.z > 1.0){
+        gVal.z = 1.0;
+    }
+    else if(gVal.z < -1.0){
+        gVal.z = -1.0;
+    }
+    angleVal.z = (asin(gVal.z)) * 57.296;
+
+    return angleVal;
+}
+
+MPU9250_orientation MPU6500_WE::getOrientation(){
+    xyzFloat angleVal = getAngles();
+    MPU9250_orientation orientation = MPU9250_FLAT;
+    if(abs(angleVal.x) < 45){      // |x| < 45
+        if(abs(angleVal.y) < 45){      // |y| < 45
+            if(angleVal.z > 0){          //  z  > 0
+                orientation = MPU9250_FLAT;
+            }
+            else{                        //  z  < 0
+                orientation = MPU9250_FLAT_1;
+            }
+        }
+        else{                         // |y| > 45
+            if(angleVal.y > 0){         //  y  > 0
+                orientation = MPU9250_XY;
+            }
+            else{                       //  y  < 0
+                orientation = MPU9250_XY_1;
+            }
+        }
+    }
+    else{                           // |x| >= 45
+        if(angleVal.x > 0){           //  x  >  0
+            orientation = MPU9250_YX;
+        }
+        else{                       //  x  <  0
+            orientation = MPU9250_YX_1;
+        }
+    }
+    return orientation;
+}
+
+String MPU6500_WE::getOrientationAsString(){
+    MPU9250_orientation orientation = getOrientation();
+    String orientationAsString = "";
+    switch(orientation){
+        case MPU9250_FLAT:      orientationAsString = "z up";   break;
+        case MPU9250_FLAT_1:    orientationAsString = "z down"; break;
+        case MPU9250_XY:        orientationAsString = "y up";   break;
+        case MPU9250_XY_1:      orientationAsString = "y down"; break;
+        case MPU9250_YX:        orientationAsString = "x up";   break;
+        case MPU9250_YX_1:      orientationAsString = "x down"; break;
+    }
+    return orientationAsString;
+}
+
+float MPU6500_WE::getPitch(){
+    xyzFloat angleVal = getAngles();
+    float pitch = (atan2(angleVal.x, sqrt(abs((angleVal.x*angleVal.y + angleVal.z*angleVal.z))))*180.0)/M_PI;
+    return pitch;
+}
+
+float MPU6500_WE::getRoll(){
+    xyzFloat angleVal = getAngles();
+    float roll = (atan2(angleVal.y, angleVal.z)*180.0)/M_PI;
+    return roll;
+}
+
+
+/************** Interrupts ***************/
+
+void MPU6500_WE::setIntPinPolarity(MPU9250_intPinPol pol){
+    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    if(pol){
+        regVal |= 0x80;
+    }
+    else{
+        regVal &= ~(0x80);
+    }
+    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+}
+
+void MPU6500_WE::enableIntLatch(bool latch){
+    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    if(latch){
+        regVal |= 0x20;
+    }
+    else{
+        regVal &= ~(0x20);
+    }
+    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+}
+
+void MPU6500_WE::enableClearIntByAnyRead(bool clearByAnyRead){
+    regVal = readMPU9250Register8(MPU6500_INT_PIN_CFG);
+    if(clearByAnyRead){
+        regVal |= 0x10;
+    }
+    else{
+        regVal &= ~(0x10);
+    }
+    writeMPU9250Register(MPU6500_INT_PIN_CFG, regVal);
+}
+
+void MPU6500_WE::enableInterrupt(MPU9250_intType intType){
+    regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    regVal |= intType;
+    writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
+}
+
+void MPU6500_WE::disableInterrupt(MPU9250_intType intType){
+    regVal = readMPU9250Register8(MPU6500_INT_ENABLE);
+    regVal &= ~intType;
+    writeMPU9250Register(MPU6500_INT_ENABLE, regVal);
+}
+
+bool MPU6500_WE::checkInterrupt(uint8_t source, MPU9250_intType type){
+    source &= type;
+    return source;
+}
+
+uint8_t MPU6500_WE::readAndClearInterrupts(){
+    regVal = readMPU9250Register8(MPU6500_INT_STATUS);
+    return regVal;
+}
+
+void MPU6500_WE::setWakeOnMotionThreshold(uint8_t womthresh){
+    writeMPU9250Register(MPU6500_WOM_THR, womthresh);
+}
+
+void MPU6500_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn){
+    regVal = 0;
+    if(womEn){
+        regVal |= 0x80;
+    }
+    if(womCompEn){
+        regVal |= 0x40;
+    }
+    writeMPU9250Register(MPU6500_MOT_DET_CTRL, regVal);
+}
+
+/***************** FIFO ******************/
+
+/* fifo is a byte which defines the data stored in the FIFO
+ * It is structured as:
+ * Bit 7 = TEMP,              Bit 6 = GYRO_X,  Bit 5 = GYRO_Y   Bit 4 = GYRO_Z,
+ * Bit 3 = ACCEL (all axes), Bit 2 = SLAVE_2, Bit 1 = SLAVE_1, Bit 0 = SLAVE_0;
+ * e.g. 0b11001001 => TEMP, GYRO_X, ACCEL, SLAVE0 are enabled
+ */
+void MPU6500_WE::startFifo(MPU9250_fifo_type fifo){
+    fifoType = fifo;
+    writeMPU9250Register(MPU6500_FIFO_EN, fifoType);
+}
+
+void MPU6500_WE::stopFifo(){
+    writeMPU9250Register(MPU6500_FIFO_EN, 0);
+}
+
+void MPU6500_WE::enableFifo(bool fifo){
+    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    if(fifo){
+        regVal |= 0x40;
+    }
+    else{
+        regVal &= ~(0x40);
+    }
+    writeMPU9250Register(MPU6500_USER_CTRL, regVal);
+}
+
+void MPU6500_WE::resetFifo(){
+    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    regVal |= 0x04;
+    writeMPU9250Register(MPU6500_USER_CTRL, regVal);
+}
+
+int16_t MPU6500_WE::getFifoCount(){
+    uint16_t regVal16 = (uint16_t) readMPU9250Register16(MPU6500_FIFO_COUNT);
+    return regVal16;
+}
+
+void MPU6500_WE::setFifoMode(MPU9250_fifoMode mode){
+    regVal = readMPU9250Register8(MPU6500_CONFIG);
+    if(mode){
+        regVal |= 0x40;
+    }
+    else{
+        regVal &= ~(0x40);
+    }
+    writeMPU9250Register(MPU6500_CONFIG, regVal);
+
+}
+
+int16_t MPU6500_WE::getNumberOfFifoDataSets(){
+    int16_t numberOfSets = getFifoCount();
+
+    if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
+        numberOfSets /= 6;
+    }
+    else if(fifoType==MPU9250_FIFO_ACC_GYR){
+        numberOfSets /= 12;
+    }
+
+    return numberOfSets;
+}
+
+void MPU6500_WE::findFifoBegin(){
+    int16_t count = getFifoCount();
+
+    if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
+        if(count > 510){
+            for(int i=0; i<2; i++){
+                readMPU9250Register8(MPU6500_FIFO_R_W);
+            }
+        }
+    }
+    else if(fifoType==MPU9250_FIFO_ACC_GYR){
+        if(count > 504){
+            for(int i=0; i<8; i++){
+                readMPU9250Register8(MPU6500_FIFO_R_W);
+            }
+        }
+    }
+}
+
+/************************************************
+     Private Functions
+*************************************************/
+
+void MPU6500_WE::correctAccRawValues(){
+    accRawVal.x -= (accOffsetVal.x / accRangeFactor);
+    accRawVal.y -= (accOffsetVal.y / accRangeFactor);
+    accRawVal.z -= (accOffsetVal.z / accRangeFactor);
+}
+
+void MPU6500_WE::correctGyrRawValues(){
+    gyrRawVal.x -= (gyrOffsetVal.x / gyrRangeFactor);
+    gyrRawVal.y -= (gyrOffsetVal.y / gyrRangeFactor);
+    gyrRawVal.z -= (gyrOffsetVal.z / gyrRangeFactor);
+}
+
+void MPU6500_WE::reset_MPU9250(){
+    writeMPU9250Register(MPU6500_PWR_MGMT_1, MPU6500_RESET);
+    delay(10);  // wait for registers to reset
+}
+
+void MPU6500_WE::enableI2CMaster(){
+    regVal = readMPU9250Register8(MPU6500_USER_CTRL);
+    regVal |= MPU6500_I2C_MST_EN;
+    writeMPU9250Register(MPU6500_USER_CTRL, regVal); //enable I2C master
+    writeMPU9250Register(MPU6500_I2C_MST_CTRL, 0x00); // set I2C clock to 400 kHz
+    delay(10);
+}
+
+void MPU6500_WE::writeMPU9250Register(uint8_t reg, uint8_t val){
+    _wire->beginTransmission(i2cAddress);
+    _wire->write(reg);
+    _wire->write(val);
+    _wire->endTransmission();
+}
+
+uint8_t MPU6500_WE::readMPU9250Register8(uint8_t reg){
+    uint8_t regValue = 0;
+    _wire->beginTransmission(i2cAddress);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(i2cAddress,1);
+    if(_wire->available()){
+        regValue = _wire->read();
+    }
+    return regValue;
+}
+
+int16_t MPU6500_WE::readMPU9250Register16(uint8_t reg){
+    uint8_t MSByte = 0, LSByte = 0;
+    int16_t regValue = 0;
+    _wire->beginTransmission(i2cAddress);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(i2cAddress,2);
+    if(_wire->available()){
+        MSByte = _wire->read();
+        LSByte = _wire->read();
+    }
+    regValue = (MSByte<<8) + LSByte;
+    return regValue;
+}
+
+uint64_t MPU6500_WE::readMPU9250Register3x16(uint8_t reg){
+    uint8_t mpu9250Triple[6];
+    uint64_t regValue = 0;
+
+    _wire->beginTransmission(i2cAddress);
+    _wire->write(reg);
+    _wire->endTransmission(false);
+    _wire->requestFrom(i2cAddress,6);
+    if(_wire->available()){
+        for(int i=0; i<6; i++){
+            mpu9250Triple[i] = _wire->read();
+        }
+    }
+
+    regValue = ((uint64_t) mpu9250Triple[0]<<40) + ((uint64_t) mpu9250Triple[1]<<32) +((uint64_t) mpu9250Triple[2]<<24) +
+           + ((uint64_t) mpu9250Triple[3]<<16) + ((uint64_t) mpu9250Triple[4]<<8) +  (uint64_t) mpu9250Triple[5];
+    return regValue;
+}
+
+xyzFloat MPU6500_WE::readMPU9250xyzValFromFifo(){
+    uint8_t fifoTriple[6];
+    xyzFloat xyzResult = {0.0, 0.0, 0.0};
+
+    _wire->beginTransmission(i2cAddress);
+    _wire->write(MPU6500_FIFO_R_W);
+    _wire->endTransmission(false);
+    _wire->requestFrom(i2cAddress,6);
+    if(_wire->available()){
+        for(int i=0; i<6; i++){
+            fifoTriple[i] = _wire->read();
+        }
+    }
+
+    xyzResult.x = ((int16_t)((fifoTriple[0]<<8) + fifoTriple[1])) * 1.0;
+    xyzResult.y = ((int16_t)((fifoTriple[2]<<8) + fifoTriple[3])) * 1.0;
+    xyzResult.z = ((int16_t)((fifoTriple[4]<<8) + fifoTriple[5])) * 1.0;
+
+    return xyzResult;
 }
 
 /************ end ************/

--- a/src/MPU6500_WE.cpp
+++ b/src/MPU6500_WE.cpp
@@ -224,14 +224,6 @@ uint8_t MPU6500_WE::whoAmI(){
 }
 
 void MPU6500_WE::autoOffsets(){
-    accOffsetVal.x = 0.0;
-    accOffsetVal.y = 0.0;
-    accOffsetVal.z = 0.0;
-
-    gyrOffsetVal.x = 0.0;
-    gyrOffsetVal.y = 0.0;
-    gyrOffsetVal.z = 0.0;
-
     enableGyrDLPF();
     setGyrDLPF(MPU9250_DLPF_6);  // lowest noise
     setGyrRange(MPU9250_GYRO_RANGE_250); // highest resolution
@@ -240,29 +232,22 @@ void MPU6500_WE::autoOffsets(){
     setAccDLPF(MPU9250_DLPF_6);
     delay(100);
 
+    xyzFloat accelerationOffsetAccumulator{0.f, 0.f, 0.f};
+    xyzFloat gyroOffsetAccumulator{0.f, 0.f, 0.f};
     for(int i=0; i<50; i++){
         // acceleration
-        xyzFloat const accRawVal = getAccRawValues();
-        accOffsetVal.x += accRawVal.x;
-        accOffsetVal.y += accRawVal.y;
-        accOffsetVal.z += accRawVal.z;
+        accelerationOffsetAccumulator += getAccRawValues();
         // gyro
-        xyzFloat const gyrRawVal = getGyrRawValues();
-        gyrOffsetVal.x += gyrRawVal.x;
-        gyrOffsetVal.y += gyrRawVal.y;
-        gyrOffsetVal.z += gyrRawVal.z;
+        gyroOffsetAccumulator += getGyrRawValues();
         delay(1);
     }
 
     // acceleration
-    accOffsetVal.x /= 50;
-    accOffsetVal.y /= 50;
-    accOffsetVal.z /= 50;
-    accOffsetVal.z -= 16384.0;
+    accelerationOffsetAccumulator /= 50.f;
+    accelerationOffsetAccumulator.z -= 16384.0f;
+    accOffsetVal = accelerationOffsetAccumulator;
     // gyro
-    gyrOffsetVal.x /= 50;
-    gyrOffsetVal.y /= 50;
-    gyrOffsetVal.z /= 50;
+    gyrOffsetVal = gyroOffsetAccumulator / 50.f;
 
 }
 

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -90,6 +90,9 @@ struct xyzFloat {
     float y;
     float z;
 
+    xyzFloat();
+    xyzFloat(float const x, float const y, float const z);
+
     xyzFloat operator+() const;
     xyzFloat operator-() const;
     xyzFloat operator+(xyzFloat const & summand) const;

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -7,10 +7,153 @@
 #ifndef MPU6500_WE_H_
 #define MPU6500_WE_H_
 
-#include "MPU9250_WE.h"
+#if (ARDUINO >= 100)
+ #include "Arduino.h"
+#else
+ #include "WProgram.h"
+#endif
+
+#include <Wire.h>
+
+/* Registers MPU6500*/
+static uint8_t constexpr MPU6500_SELF_TEST_X_GYRO       = 0x00;
+static uint8_t constexpr MPU6500_SELF_TEST_Y_GYRO       = 0x01;
+static uint8_t constexpr MPU6500_SELF_TEST_Z_GYRO       = 0x02;
+static uint8_t constexpr MPU6500_SELF_TEST_X_ACCEL      = 0x0D;
+static uint8_t constexpr MPU6500_SELF_TEST_Y_ACCEL      = 0x0E;
+static uint8_t constexpr MPU6500_SELF_TEST_Z_ACCEL      = 0x0F;
+static uint8_t constexpr MPU6500_XG_OFFSET_H            = 0x13;
+static uint8_t constexpr MPU6500_XG_OFFSET_L            = 0x14;
+static uint8_t constexpr MPU6500_YG_OFFSET_H            = 0x15;
+static uint8_t constexpr MPU6500_YG_OFFSET_L            = 0x16;
+static uint8_t constexpr MPU6500_ZG_OFFSET_H            = 0x17;
+static uint8_t constexpr MPU6500_ZG_OFFSET_L            = 0x18;
+static uint8_t constexpr MPU6500_SMPLRT_DIV             = 0x19;
+static uint8_t constexpr MPU6500_CONFIG                 = 0x1A;
+static uint8_t constexpr MPU6500_GYRO_CONFIG            = 0x1B;
+static uint8_t constexpr MPU6500_ACCEL_CONFIG           = 0x1C;
+static uint8_t constexpr MPU6500_ACCEL_CONFIG_2         = 0x1D;
+static uint8_t constexpr MPU6500_LP_ACCEL_ODR           = 0x1E;
+static uint8_t constexpr MPU6500_WOM_THR                = 0x1F;
+static uint8_t constexpr MPU6500_FIFO_EN                = 0x23;
+static uint8_t constexpr MPU6500_I2C_MST_CTRL           = 0x24;
+static uint8_t constexpr MPU6500_I2C_SLV0_ADDR          = 0x25;
+static uint8_t constexpr MPU6500_I2C_SLV0_REG           = 0x26;
+static uint8_t constexpr MPU6500_I2C_SLV0_CTRL          = 0x27;
+static uint8_t constexpr MPU6500_I2C_MST_STATUS         = 0x36;
+static uint8_t constexpr MPU6500_INT_PIN_CFG            = 0x37;
+static uint8_t constexpr MPU6500_INT_ENABLE             = 0x38;
+static uint8_t constexpr MPU6500_INT_STATUS             = 0x3A;
+static uint8_t constexpr MPU6500_ACCEL_OUT              = 0x3B; // accel data registers begin
+static uint8_t constexpr MPU6500_TEMP_OUT               = 0x41;
+static uint8_t constexpr MPU6500_GYRO_OUT               = 0x43; // gyro data registers begin
+static uint8_t constexpr MPU6500_EXT_SLV_SENS_DATA_00   = 0x49;
+static uint8_t constexpr MPU6500_I2C_SLV0_DO            = 0x63;
+static uint8_t constexpr MPU6500_I2C_MST_DELAY_CTRL     = 0x67;
+static uint8_t constexpr MPU6500_SIGNAL_PATH_RESET      = 0x68;
+static uint8_t constexpr MPU6500_MOT_DET_CTRL           = 0x69;
+static uint8_t constexpr MPU6500_USER_CTRL              = 0x6A;
+static uint8_t constexpr MPU6500_PWR_MGMT_1             = 0x6B;
+static uint8_t constexpr MPU6500_PWR_MGMT_2             = 0x6C;
+static uint8_t constexpr MPU6500_FIFO_COUNT             = 0x72; // 0x72 is COUNT_H
+static uint8_t constexpr MPU6500_FIFO_R_W               = 0x74;
+static uint8_t constexpr MPU6500_WHO_AM_I               = 0x75;
+static uint8_t constexpr MPU6500_XA_OFFSET_H            = 0x77;
+static uint8_t constexpr MPU6500_XA_OFFSET_L            = 0x78;
+static uint8_t constexpr MPU6500_YA_OFFSET_H            = 0x7A;
+static uint8_t constexpr MPU6500_YA_OFFSET_L            = 0x7B;
+static uint8_t constexpr MPU6500_ZA_OFFSET_H            = 0x7D;
+static uint8_t constexpr MPU6500_ZA_OFFSET_L            = 0x7E;
+
+/* Register Values */
+static uint8_t constexpr MPU6500_RESET       = 0x80;
+static uint8_t constexpr MPU6500_BYPASS_EN   = 0x02;
+static uint8_t constexpr MPU6500_I2C_MST_EN  = 0x20;
+static uint8_t constexpr MPU6500_CLK_SEL_PLL = 0x01;
+
+/* Others */
+static float constexpr MPU6500_ROOM_TEMP_OFFSET    = 0.0f;
+static float constexpr MPU6500_T_SENSITIVITY       = 333.87f;
+static float constexpr MPU6500_WHO_AM_I_CODE       = 0x70;
 
 
-class MPU6500_WE : protected MPU9250_WE
+/* Enums */
+
+typedef enum MPU9250_BW_WO_DLPF {
+    MPU9250_BW_WO_DLPF_3600 = 0x02,
+    MPU9250_BW_WO_DLPF_8800 = 0x01
+} MPU9250_bw_wo_dlpf;
+
+typedef enum MPU9250_DLPF {
+    MPU9250_DLPF_0, MPU9250_DLPF_1, MPU9250_DLPF_2, MPU9250_DLPF_3, MPU9250_DLPF_4, MPU9250_DLPF_5,
+    MPU9250_DLPF_6, MPU9250_DLPF_7
+} MPU9250_dlpf;
+
+typedef enum MPU9250_GYRO_RANGE {
+    MPU9250_GYRO_RANGE_250, MPU9250_GYRO_RANGE_500, MPU9250_GYRO_RANGE_1000, MPU9250_GYRO_RANGE_2000
+} MPU9250_gyroRange;
+
+typedef enum MPU9250_ACC_RANGE {
+    MPU9250_ACC_RANGE_2G, MPU9250_ACC_RANGE_4G, MPU9250_ACC_RANGE_8G, MPU9250_ACC_RANGE_16G
+} MPU9250_accRange;
+
+typedef enum MPU9250_LOW_PWR_ACC_ODR {
+    MPU9250_LP_ACC_ODR_0_24, MPU9250_LP_ACC_ODR_0_49, MPU9250_LP_ACC_ODR_0_98, MPU9250_LP_ACC_ODR_1_95,
+    MPU9250_LP_ACC_ODR_3_91, MPU9250_LP_ACC_ODR_7_81, MPU9250_LP_ACC_ODR_15_63, MPU9250_LP_ACC_ODR_31_25,
+    MPU9250_LP_ACC_ODR_62_5, MPU9250_LP_ACC_ODR_125, MPU9250_LP_ACC_ODR_250, MPU9250_LP_ACC_ODR_500
+} MPU9250_lpAccODR;
+
+typedef enum MPU9250_INT_PIN_POL {
+    MPU9250_ACT_HIGH, MPU9250_ACT_LOW
+} MPU9250_intPinPol;
+
+typedef enum MPU9250_INT_TYPE {
+    MPU9250_DATA_READY = 0x01,
+    MPU9250_FIFO_OVF   = 0x10,
+    MPU9250_WOM_INT    = 0x40
+} MPU9250_intType;
+
+typedef enum MPU9250_WOM_EN {
+    MPU9250_WOM_DISABLE, MPU9250_WOM_ENABLE
+} MPU9250_womEn;
+
+typedef enum MPU9250_WOM_COMP {
+    MPU9250_WOM_COMP_DISABLE, MPU9250_WOM_COMP_ENABLE
+} MPU9250_womCompEn;
+
+typedef enum MPU9250_XYZ_ENABLE {
+    MPU9250_ENABLE_XYZ,  //all axes are enabled (default)
+    MPU9250_ENABLE_XY0,  // x, y enabled, z disabled
+    MPU9250_ENABLE_X0Z,
+    MPU9250_ENABLE_X00,
+    MPU9250_ENABLE_0YZ,
+    MPU9250_ENABLE_0Y0,
+    MPU9250_ENABLE_00Z,
+    MPU9250_ENABLE_000,  // all axes disabled
+} MPU9250_xyzEn;
+
+typedef enum MPU9250_ORIENTATION {
+  MPU9250_FLAT, MPU9250_FLAT_1, MPU9250_XY, MPU9250_XY_1, MPU9250_YX, MPU9250_YX_1
+} MPU9250_orientation;
+
+typedef enum MPU9250_FIFO_MODE {
+    MPU9250_CONTINUOUS, MPU9250_STOP_WHEN_FULL
+} MPU9250_fifoMode;
+
+typedef enum MPU9250_FIFO_TYPE {
+    MPU9250_FIFO_ACC        = 0x08,
+    MPU9250_FIFO_GYR        = 0x70,
+    MPU9250_FIFO_ACC_GYR    = 0x78
+} MPU9250_fifo_type;
+
+struct xyzFloat {
+    float x;
+    float y;
+    float z;
+};
+
+
+class MPU6500_WE
 {
 public:
     /* Constructors */
@@ -23,77 +166,101 @@ public:
     /* Basic settings */
 
     bool init();
-
-    /* reuse MPU9250_WE */
-
-    using MPU9250_WE::whoAmI;
-    using MPU9250_WE::autoOffsets;
-    using MPU9250_WE::setAccOffsets;
-    using MPU9250_WE::setGyrOffsets;
-    using MPU9250_WE::setGyrDLPF;
-    using MPU9250_WE::setSampleRateDivider;
-    using MPU9250_WE::setGyrRange;
-    using MPU9250_WE::enableGyrDLPF;
-    using MPU9250_WE::disableGyrDLPF;
-    using MPU9250_WE::setAccRange;
-    using MPU9250_WE::enableAccDLPF;
-    using MPU9250_WE::setAccDLPF;
-    using MPU9250_WE::setLowPowerAccDataRate;
-    using MPU9250_WE::enableAccAxes;
-    using MPU9250_WE::enableGyrAxes;
+    uint8_t whoAmI();
+    void autoOffsets();
+    void setAccOffsets(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax);
+    void setGyrOffsets(float xOffset, float yOffset, float zOffset);
+    void setGyrDLPF(MPU9250_dlpf dlpf);
+    void setSampleRateDivider(uint8_t splRateDiv);
+    void setGyrRange(MPU9250_gyroRange gyroRange);
+    void enableGyrDLPF();
+    void disableGyrDLPF(MPU9250_bw_wo_dlpf bw);
+    void setAccRange(MPU9250_accRange accRange);
+    void enableAccDLPF(bool enable);
+    void setAccDLPF(MPU9250_dlpf dlpf);
+    void setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr);
+    void enableAccAxes(MPU9250_xyzEn enable);
+    void enableGyrAxes(MPU9250_xyzEn enable);
 
     /* x,y,z results */
 
-    using MPU9250_WE::getAccRawValues;
-    using MPU9250_WE::getCorrectedAccRawValues;
-    using MPU9250_WE::getGValues;
-    using MPU9250_WE::getAccRawValuesFromFifo;
-    using MPU9250_WE::getCorrectedAccRawValuesFromFifo;
-    using MPU9250_WE::getGValuesFromFifo;
-    using MPU9250_WE::getResultantG;
-    using MPU9250_WE::getTemperature;
-    using MPU9250_WE::getGyrRawValues;
-    using MPU9250_WE::getCorrectedGyrRawValues;
-    using MPU9250_WE::getGyrValues;
-    using MPU9250_WE::getGyrValuesFromFifo;
+    xyzFloat getAccRawValues();
+    xyzFloat getCorrectedAccRawValues();
+    xyzFloat getGValues();
+    xyzFloat getAccRawValuesFromFifo();
+    xyzFloat getCorrectedAccRawValuesFromFifo();
+    xyzFloat getGValuesFromFifo();
+    float getResultantG(xyzFloat gVal);
+    float getTemperature();
+    xyzFloat getGyrRawValues();
+    xyzFloat getCorrectedGyrRawValues();
+    xyzFloat getGyrValues();
+    xyzFloat getGyrValuesFromFifo();
 
 
     /* Angles and Orientation */
 
-    using MPU9250_WE::getAngles;
-    using MPU9250_WE::getOrientation;
-    using MPU9250_WE::getOrientationAsString;
-    using MPU9250_WE::getPitch;
-    using MPU9250_WE::getRoll;
+    xyzFloat getAngles();
+    MPU9250_orientation getOrientation();
+    String getOrientationAsString();
+    float getPitch();
+    float getRoll();
 
     /* Power, Sleep, Standby */
 
-    using MPU9250_WE::sleep;
-    using MPU9250_WE::enableCycle;
-    using MPU9250_WE::enableGyrStandby;
+    void sleep(bool sleep);
+    void enableCycle(bool cycle);
+    void enableGyrStandby(bool gyroStandby);
 
     /* Interrupts */
 
-    using MPU9250_WE::setIntPinPolarity;
-    using MPU9250_WE::enableIntLatch;
-    using MPU9250_WE::enableClearIntByAnyRead;
-    using MPU9250_WE::enableInterrupt;
-    using MPU9250_WE::disableInterrupt;
-    using MPU9250_WE::checkInterrupt;
-    using MPU9250_WE::readAndClearInterrupts;
-    using MPU9250_WE::setWakeOnMotionThreshold;
-    using MPU9250_WE::enableWakeOnMotion;
+    void setIntPinPolarity(MPU9250_intPinPol pol);
+    void enableIntLatch(bool latch);
+    void enableClearIntByAnyRead(bool clearByAnyRead);
+    void enableInterrupt(MPU9250_intType intType);
+    void disableInterrupt(MPU9250_intType intType);
+    bool checkInterrupt(uint8_t source, MPU9250_intType type);
+    uint8_t readAndClearInterrupts();
+    void setWakeOnMotionThreshold(uint8_t womthresh);
+    void enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn);
 
     /* FIFO */
 
-    using MPU9250_WE::startFifo;
-    using MPU9250_WE::stopFifo;
-    using MPU9250_WE::enableFifo;
-    using MPU9250_WE::resetFifo;
-    using MPU9250_WE::getFifoCount;
-    using MPU9250_WE::setFifoMode;
-    using MPU9250_WE::getNumberOfFifoDataSets;
-    using MPU9250_WE::findFifoBegin;
+    void startFifo(MPU9250_fifo_type fifo);
+    void stopFifo();
+    void enableFifo(bool fifo);
+    void resetFifo();
+    int16_t getFifoCount();
+    void setFifoMode(MPU9250_fifoMode mode);
+    int16_t getNumberOfFifoDataSets();
+    void findFifoBegin();
+
+protected:
+
+    bool init(uint8_t const expectedValue);
+
+    void correctAccRawValues();
+    void correctGyrRawValues();
+    void getAsaVals();
+    void reset_MPU9250();
+    void enableI2CMaster();
+    void writeMPU9250Register(uint8_t reg, uint8_t val);
+    uint8_t readMPU9250Register8(uint8_t reg);
+    int16_t readMPU9250Register16(uint8_t reg);
+    uint64_t readMPU9250Register3x16(uint8_t reg);
+    xyzFloat readMPU9250xyzValFromFifo();
+
+private:
+    TwoWire *_wire;
+    int i2cAddress;
+    xyzFloat accRawVal;
+    xyzFloat gyrRawVal;
+    xyzFloat accOffsetVal;
+    xyzFloat gyrOffsetVal;
+    uint8_t accRangeFactor;
+    uint8_t gyrRangeFactor;
+    uint8_t regVal;   // intermediate storage of register values
+    MPU9250_fifo_type fifoType;
 
 };
 

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -250,9 +250,10 @@ protected:
     uint64_t readMPU9250Register3x16(uint8_t reg);
     xyzFloat readMPU9250xyzValFromFifo();
 
+    TwoWire * const _wire;
+    int const i2cAddress;
+
 private:
-    TwoWire *_wire;
-    int i2cAddress;
     xyzFloat accRawVal;
     xyzFloat gyrRawVal;
     xyzFloat accOffsetVal;

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -239,7 +239,7 @@ protected:
     bool init(uint8_t const expectedValue);
 
     void correctAccRawValues(xyzFloat & rawValues);
-    void correctGyrRawValues();
+    void correctGyrRawValues(xyzFloat & rawValues);
     void getAsaVals();
     void reset_MPU9250();
     void enableI2CMaster();
@@ -253,7 +253,6 @@ protected:
     int const i2cAddress;
 
 private:
-    xyzFloat gyrRawVal;
     xyzFloat accOffsetVal;
     xyzFloat gyrOffsetVal;
     uint8_t accRangeFactor;

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -15,67 +15,6 @@
 
 #include <Wire.h>
 
-/* Registers MPU6500*/
-static uint8_t constexpr MPU6500_SELF_TEST_X_GYRO       = 0x00;
-static uint8_t constexpr MPU6500_SELF_TEST_Y_GYRO       = 0x01;
-static uint8_t constexpr MPU6500_SELF_TEST_Z_GYRO       = 0x02;
-static uint8_t constexpr MPU6500_SELF_TEST_X_ACCEL      = 0x0D;
-static uint8_t constexpr MPU6500_SELF_TEST_Y_ACCEL      = 0x0E;
-static uint8_t constexpr MPU6500_SELF_TEST_Z_ACCEL      = 0x0F;
-static uint8_t constexpr MPU6500_XG_OFFSET_H            = 0x13;
-static uint8_t constexpr MPU6500_XG_OFFSET_L            = 0x14;
-static uint8_t constexpr MPU6500_YG_OFFSET_H            = 0x15;
-static uint8_t constexpr MPU6500_YG_OFFSET_L            = 0x16;
-static uint8_t constexpr MPU6500_ZG_OFFSET_H            = 0x17;
-static uint8_t constexpr MPU6500_ZG_OFFSET_L            = 0x18;
-static uint8_t constexpr MPU6500_SMPLRT_DIV             = 0x19;
-static uint8_t constexpr MPU6500_CONFIG                 = 0x1A;
-static uint8_t constexpr MPU6500_GYRO_CONFIG            = 0x1B;
-static uint8_t constexpr MPU6500_ACCEL_CONFIG           = 0x1C;
-static uint8_t constexpr MPU6500_ACCEL_CONFIG_2         = 0x1D;
-static uint8_t constexpr MPU6500_LP_ACCEL_ODR           = 0x1E;
-static uint8_t constexpr MPU6500_WOM_THR                = 0x1F;
-static uint8_t constexpr MPU6500_FIFO_EN                = 0x23;
-static uint8_t constexpr MPU6500_I2C_MST_CTRL           = 0x24;
-static uint8_t constexpr MPU6500_I2C_SLV0_ADDR          = 0x25;
-static uint8_t constexpr MPU6500_I2C_SLV0_REG           = 0x26;
-static uint8_t constexpr MPU6500_I2C_SLV0_CTRL          = 0x27;
-static uint8_t constexpr MPU6500_I2C_MST_STATUS         = 0x36;
-static uint8_t constexpr MPU6500_INT_PIN_CFG            = 0x37;
-static uint8_t constexpr MPU6500_INT_ENABLE             = 0x38;
-static uint8_t constexpr MPU6500_INT_STATUS             = 0x3A;
-static uint8_t constexpr MPU6500_ACCEL_OUT              = 0x3B; // accel data registers begin
-static uint8_t constexpr MPU6500_TEMP_OUT               = 0x41;
-static uint8_t constexpr MPU6500_GYRO_OUT               = 0x43; // gyro data registers begin
-static uint8_t constexpr MPU6500_EXT_SLV_SENS_DATA_00   = 0x49;
-static uint8_t constexpr MPU6500_I2C_SLV0_DO            = 0x63;
-static uint8_t constexpr MPU6500_I2C_MST_DELAY_CTRL     = 0x67;
-static uint8_t constexpr MPU6500_SIGNAL_PATH_RESET      = 0x68;
-static uint8_t constexpr MPU6500_MOT_DET_CTRL           = 0x69;
-static uint8_t constexpr MPU6500_USER_CTRL              = 0x6A;
-static uint8_t constexpr MPU6500_PWR_MGMT_1             = 0x6B;
-static uint8_t constexpr MPU6500_PWR_MGMT_2             = 0x6C;
-static uint8_t constexpr MPU6500_FIFO_COUNT             = 0x72; // 0x72 is COUNT_H
-static uint8_t constexpr MPU6500_FIFO_R_W               = 0x74;
-static uint8_t constexpr MPU6500_WHO_AM_I               = 0x75;
-static uint8_t constexpr MPU6500_XA_OFFSET_H            = 0x77;
-static uint8_t constexpr MPU6500_XA_OFFSET_L            = 0x78;
-static uint8_t constexpr MPU6500_YA_OFFSET_H            = 0x7A;
-static uint8_t constexpr MPU6500_YA_OFFSET_L            = 0x7B;
-static uint8_t constexpr MPU6500_ZA_OFFSET_H            = 0x7D;
-static uint8_t constexpr MPU6500_ZA_OFFSET_L            = 0x7E;
-
-/* Register Values */
-static uint8_t constexpr MPU6500_RESET       = 0x80;
-static uint8_t constexpr MPU6500_BYPASS_EN   = 0x02;
-static uint8_t constexpr MPU6500_I2C_MST_EN  = 0x20;
-static uint8_t constexpr MPU6500_CLK_SEL_PLL = 0x01;
-
-/* Others */
-static float constexpr MPU6500_ROOM_TEMP_OFFSET    = 0.0f;
-static float constexpr MPU6500_T_SENSITIVITY       = 333.87f;
-static float constexpr MPU6500_WHO_AM_I_CODE       = 0x70;
-
 
 /* Enums */
 
@@ -156,6 +95,68 @@ struct xyzFloat {
 class MPU6500_WE
 {
 public:
+    /* Registers MPU6500 */
+    static uint8_t constexpr REGISTER_SELF_TEST_X_GYRO       = 0x00;
+    static uint8_t constexpr REGISTER_SELF_TEST_Y_GYRO       = 0x01;
+    static uint8_t constexpr REGISTER_SELF_TEST_Z_GYRO       = 0x02;
+    static uint8_t constexpr REGISTER_SELF_TEST_X_ACCEL      = 0x0D;
+    static uint8_t constexpr REGISTER_SELF_TEST_Y_ACCEL      = 0x0E;
+    static uint8_t constexpr REGISTER_SELF_TEST_Z_ACCEL      = 0x0F;
+    static uint8_t constexpr REGISTER_XG_OFFSET_H            = 0x13;
+    static uint8_t constexpr REGISTER_XG_OFFSET_L            = 0x14;
+    static uint8_t constexpr REGISTER_YG_OFFSET_H            = 0x15;
+    static uint8_t constexpr REGISTER_YG_OFFSET_L            = 0x16;
+    static uint8_t constexpr REGISTER_ZG_OFFSET_H            = 0x17;
+    static uint8_t constexpr REGISTER_ZG_OFFSET_L            = 0x18;
+    static uint8_t constexpr REGISTER_SMPLRT_DIV             = 0x19;
+    static uint8_t constexpr REGISTER_CONFIG                 = 0x1A;
+    static uint8_t constexpr REGISTER_GYRO_CONFIG            = 0x1B;
+    static uint8_t constexpr REGISTER_ACCEL_CONFIG           = 0x1C;
+    static uint8_t constexpr REGISTER_ACCEL_CONFIG_2         = 0x1D;
+    static uint8_t constexpr REGISTER_LP_ACCEL_ODR           = 0x1E;
+    static uint8_t constexpr REGISTER_WOM_THR                = 0x1F;
+    static uint8_t constexpr REGISTER_FIFO_EN                = 0x23;
+    static uint8_t constexpr REGISTER_I2C_MST_CTRL           = 0x24;
+    static uint8_t constexpr REGISTER_I2C_SLV0_ADDR          = 0x25;
+    static uint8_t constexpr REGISTER_I2C_SLV0_REG           = 0x26;
+    static uint8_t constexpr REGISTER_I2C_SLV0_CTRL          = 0x27;
+    static uint8_t constexpr REGISTER_I2C_MST_STATUS         = 0x36;
+    static uint8_t constexpr REGISTER_INT_PIN_CFG            = 0x37;
+    static uint8_t constexpr REGISTER_INT_ENABLE             = 0x38;
+    static uint8_t constexpr REGISTER_INT_STATUS             = 0x3A;
+    static uint8_t constexpr REGISTER_ACCEL_OUT              = 0x3B; // accel data registers begin
+    static uint8_t constexpr REGISTER_TEMP_OUT               = 0x41;
+    static uint8_t constexpr REGISTER_GYRO_OUT               = 0x43; // gyro data registers begin
+    static uint8_t constexpr REGISTER_EXT_SLV_SENS_DATA_00   = 0x49;
+    static uint8_t constexpr REGISTER_I2C_SLV0_DO            = 0x63;
+    static uint8_t constexpr REGISTER_I2C_MST_DELAY_CTRL     = 0x67;
+    static uint8_t constexpr REGISTER_SIGNAL_PATH_RESET      = 0x68;
+    static uint8_t constexpr REGISTER_MOT_DET_CTRL           = 0x69;
+    static uint8_t constexpr REGISTER_USER_CTRL              = 0x6A;
+    static uint8_t constexpr REGISTER_PWR_MGMT_1             = 0x6B;
+    static uint8_t constexpr REGISTER_PWR_MGMT_2             = 0x6C;
+    static uint8_t constexpr REGISTER_FIFO_COUNT             = 0x72; // 0x72 is COUNT_H
+    static uint8_t constexpr REGISTER_FIFO_R_W               = 0x74;
+    static uint8_t constexpr REGISTER_WHO_AM_I               = 0x75;
+    static uint8_t constexpr REGISTER_XA_OFFSET_H            = 0x77;
+    static uint8_t constexpr REGISTER_XA_OFFSET_L            = 0x78;
+    static uint8_t constexpr REGISTER_YA_OFFSET_H            = 0x7A;
+    static uint8_t constexpr REGISTER_YA_OFFSET_L            = 0x7B;
+    static uint8_t constexpr REGISTER_ZA_OFFSET_H            = 0x7D;
+    static uint8_t constexpr REGISTER_ZA_OFFSET_L            = 0x7E;
+
+    /* Register Values */
+    static uint8_t constexpr REGISTER_VALUE_RESET            = 0x80;
+    static uint8_t constexpr REGISTER_VALUE_BYPASS_EN        = 0x02;
+    static uint8_t constexpr REGISTER_VALUE_I2C_MST_EN       = 0x20;
+    static uint8_t constexpr REGISTER_VALUE_CLK_SEL_PLL      = 0x01;
+
+    /* Others */
+    static float constexpr ROOM_TEMPERATURE_OFFSET           = 0.0f;
+    static float constexpr TEMPERATURE_SENSITIVITY           = 333.87f;
+    static float constexpr WHO_AM_I_CODE                     = 0x70;
+
+
     /* Constructors */
 
     MPU6500_WE(int const addr);

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -1,0 +1,100 @@
+/******************************************************************************
+ *
+ * This is a library for the 6-axis gyroscope and accelerometer MPU6500.
+ *
+ ******************************************************************************/
+
+#ifndef MPU6500_WE_H_
+#define MPU6500_WE_H_
+
+#include "MPU9250_WE.h"
+
+
+class MPU6500_WE : protected MPU9250_WE
+{
+public:
+    /* Constructors */
+
+    MPU6500_WE(int const addr);
+    MPU6500_WE();
+    MPU6500_WE(TwoWire * const w, int const addr);
+    MPU6500_WE(TwoWire * const w);
+
+    /* Basic settings */
+
+    bool init();
+
+    /* reuse MPU9250_WE */
+
+    using MPU9250_WE::whoAmI;
+    using MPU9250_WE::autoOffsets;
+    using MPU9250_WE::setAccOffsets;
+    using MPU9250_WE::setGyrOffsets;
+    using MPU9250_WE::setGyrDLPF;
+    using MPU9250_WE::setSampleRateDivider;
+    using MPU9250_WE::setGyrRange;
+    using MPU9250_WE::enableGyrDLPF;
+    using MPU9250_WE::disableGyrDLPF;
+    using MPU9250_WE::setAccRange;
+    using MPU9250_WE::enableAccDLPF;
+    using MPU9250_WE::setAccDLPF;
+    using MPU9250_WE::setLowPowerAccDataRate;
+    using MPU9250_WE::enableAccAxes;
+    using MPU9250_WE::enableGyrAxes;
+
+    /* x,y,z results */
+
+    using MPU9250_WE::getAccRawValues;
+    using MPU9250_WE::getCorrectedAccRawValues;
+    using MPU9250_WE::getGValues;
+    using MPU9250_WE::getAccRawValuesFromFifo;
+    using MPU9250_WE::getCorrectedAccRawValuesFromFifo;
+    using MPU9250_WE::getGValuesFromFifo;
+    using MPU9250_WE::getResultantG;
+    using MPU9250_WE::getTemperature;
+    using MPU9250_WE::getGyrRawValues;
+    using MPU9250_WE::getCorrectedGyrRawValues;
+    using MPU9250_WE::getGyrValues;
+    using MPU9250_WE::getGyrValuesFromFifo;
+
+
+    /* Angles and Orientation */
+
+    using MPU9250_WE::getAngles;
+    using MPU9250_WE::getOrientation;
+    using MPU9250_WE::getOrientationAsString;
+    using MPU9250_WE::getPitch;
+    using MPU9250_WE::getRoll;
+
+    /* Power, Sleep, Standby */
+
+    using MPU9250_WE::sleep;
+    using MPU9250_WE::enableCycle;
+    using MPU9250_WE::enableGyrStandby;
+
+    /* Interrupts */
+
+    using MPU9250_WE::setIntPinPolarity;
+    using MPU9250_WE::enableIntLatch;
+    using MPU9250_WE::enableClearIntByAnyRead;
+    using MPU9250_WE::enableInterrupt;
+    using MPU9250_WE::disableInterrupt;
+    using MPU9250_WE::checkInterrupt;
+    using MPU9250_WE::readAndClearInterrupts;
+    using MPU9250_WE::setWakeOnMotionThreshold;
+    using MPU9250_WE::enableWakeOnMotion;
+
+    /* FIFO */
+
+    using MPU9250_WE::startFifo;
+    using MPU9250_WE::stopFifo;
+    using MPU9250_WE::enableFifo;
+    using MPU9250_WE::resetFifo;
+    using MPU9250_WE::getFifoCount;
+    using MPU9250_WE::setFifoMode;
+    using MPU9250_WE::getNumberOfFifoDataSets;
+    using MPU9250_WE::findFifoBegin;
+
+};
+
+#endif // MPU6500_WE_H_

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -99,6 +99,10 @@ struct xyzFloat {
     xyzFloat operator-(xyzFloat const & subtrahend) const;
     xyzFloat operator*(float const operand) const;
     xyzFloat operator/(float const divisor) const;
+    xyzFloat & operator+=(xyzFloat const & summand);
+    xyzFloat & operator-=(xyzFloat const & subtrahend);
+    xyzFloat & operator*=(float const operand);
+    xyzFloat & operator/=(float const divisor);
 };
 
 

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -260,7 +260,6 @@ private:
     xyzFloat gyrOffsetVal;
     uint8_t accRangeFactor;
     uint8_t gyrRangeFactor;
-    uint8_t regVal;   // intermediate storage of register values
     MPU9250_fifo_type fifoType;
 
 };

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -159,9 +159,7 @@ public:
     /* Constructors */
 
     MPU6500_WE(int const addr);
-    MPU6500_WE();
-    MPU6500_WE(TwoWire * const w, int const addr);
-    MPU6500_WE(TwoWire * const w);
+    MPU6500_WE(TwoWire * const w = &Wire, int const addr = 0x68);
 
     /* Basic settings */
 

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -89,6 +89,13 @@ struct xyzFloat {
     float x;
     float y;
     float z;
+
+    xyzFloat operator+() const;
+    xyzFloat operator-() const;
+    xyzFloat operator+(xyzFloat const & summand) const;
+    xyzFloat operator-(xyzFloat const & subtrahend) const;
+    xyzFloat operator*(float const operand) const;
+    xyzFloat operator/(float const divisor) const;
 };
 
 

--- a/src/MPU6500_WE.h
+++ b/src/MPU6500_WE.h
@@ -238,7 +238,7 @@ protected:
 
     bool init(uint8_t const expectedValue);
 
-    void correctAccRawValues();
+    void correctAccRawValues(xyzFloat & rawValues);
     void correctGyrRawValues();
     void getAsaVals();
     void reset_MPU9250();
@@ -253,7 +253,6 @@ protected:
     int const i2cAddress;
 
 private:
-    xyzFloat accRawVal;
     xyzFloat gyrRawVal;
     xyzFloat accOffsetVal;
     xyzFloat gyrOffsetVal;

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -1,19 +1,19 @@
 /********************************************************************
 * This is a library for the 9-axis gyroscope, accelerometer and magnetometer MPU9250.
 *
-* You'll find an example which should enable you to use the library. 
+* You'll find an example which should enable you to use the library.
 *
-* You are free to use it, change it or build on it. In case you like 
+* You are free to use it, change it or build on it. In case you like
 * it, it would be cool if you give it a star.
-* 
+*
 * If you find bugs, please inform me!
-* 
+*
 * Written by Wolfgang (Wolle) Ewald
 *
 * For further information visit my blog:
 *
 * https://wolles-elektronikkiste.de/mpu9250-9-achsen-sensormodul-teil-1  (German)
-* https://wolles-elektronikkiste.de/en/mpu9250-9-axis-sensor-module-part-1  (English) 
+* https://wolles-elektronikkiste.de/en/mpu9250-9-axis-sensor-module-part-1  (English)
 *
 *********************************************************************/
 
@@ -23,17 +23,17 @@
 
 MPU9250_WE::MPU9250_WE(int addr){
     _wire = &Wire;
-    i2cAddress = addr;   
+    i2cAddress = addr;
 }
 
 MPU9250_WE::MPU9250_WE(){
     _wire = &Wire;
-    i2cAddress = 0x68;   
+    i2cAddress = 0x68;
 }
 
 MPU9250_WE::MPU9250_WE(TwoWire *w, int addr){
     _wire = w;
-    i2cAddress = addr; 
+    i2cAddress = addr;
 }
 
 MPU9250_WE::MPU9250_WE(TwoWire *w){
@@ -81,7 +81,7 @@ void MPU9250_WE::autoOffsets(){
     accOffsetVal.x = 0.0;
     accOffsetVal.y = 0.0;
     accOffsetVal.z = 0.0;
-    
+
     enableGyrDLPF();
     setGyrDLPF(MPU9250_DLPF_6);  // lowest noise
     setGyrRange(MPU9250_GYRO_RANGE_250); // highest resolution
@@ -89,7 +89,7 @@ void MPU9250_WE::autoOffsets(){
     enableAccDLPF(true);
     setAccDLPF(MPU9250_DLPF_6);
     delay(100);
-    
+
     for(int i=0; i<50; i++){
         getAccRawValues();
         accOffsetVal.x += accRawVal.x;
@@ -97,12 +97,12 @@ void MPU9250_WE::autoOffsets(){
         accOffsetVal.z += accRawVal.z;
         delay(1);
     }
-    
+
     accOffsetVal.x /= 50;
     accOffsetVal.y /= 50;
     accOffsetVal.z /= 50;
     accOffsetVal.z -= 16384.0;
-    
+
     for(int i=0; i<50; i++){
         getGyrRawValues();
         gyrOffsetVal.x += gyrRawVal.x;
@@ -110,11 +110,11 @@ void MPU9250_WE::autoOffsets(){
         gyrOffsetVal.z += gyrRawVal.z;
         delay(1);
     }
-    
+
     gyrOffsetVal.x /= 50;
     gyrOffsetVal.y /= 50;
     gyrOffsetVal.z /= 50;
-    
+
 }
 
 void MPU9250_WE::setAccOffsets(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax){
@@ -188,7 +188,7 @@ void MPU9250_WE::setAccDLPF(MPU9250_dlpf dlpf){
 }
 
 void MPU9250_WE::setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr){
-    writeMPU9250Register(MPU9250_LP_ACCEL_ODR, lpaodr); 
+    writeMPU9250Register(MPU9250_LP_ACCEL_ODR, lpaodr);
 }
 
 void MPU9250_WE::enableAccAxes(MPU9250_xyzEn enable){
@@ -206,17 +206,17 @@ void MPU9250_WE::enableGyrAxes(MPU9250_xyzEn enable){
 }
 
 /************* x,y,z results *************/
-        
+
 xyzFloat MPU9250_WE::getAccRawValues(){
     uint64_t xyzDataReg = readMPU9250Register3x16(MPU9250_ACCEL_OUT);
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-    
+
     accRawVal.x = xRaw * 1.0;
     accRawVal.y = yRaw * 1.0;
     accRawVal.z = zRaw * 1.0;
-     
+
     return accRawVal;
 }
 
@@ -225,20 +225,20 @@ xyzFloat MPU9250_WE::getCorrectedAccRawValues(){
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-    
+
     accRawVal.x = xRaw * 1.0;
     accRawVal.y = yRaw * 1.0;
     accRawVal.z = zRaw * 1.0;
-    
+
     correctAccRawValues();
-    
+
     return accRawVal;
 }
 
 xyzFloat MPU9250_WE::getGValues(){
     xyzFloat gVal;
     getCorrectedAccRawValues();
-    
+
     gVal.x = accRawVal.x * accRangeFactor / 16384.0;
     gVal.y = accRawVal.y * accRangeFactor / 16384.0;
     gVal.z = accRawVal.z * accRangeFactor / 16384.0;
@@ -247,21 +247,21 @@ xyzFloat MPU9250_WE::getGValues(){
 
 xyzFloat MPU9250_WE::getAccRawValuesFromFifo(){
     xyzFloat accRawVal = readMPU9250xyzValFromFifo();
-    return accRawVal;   
+    return accRawVal;
 }
 
 xyzFloat MPU9250_WE::getCorrectedAccRawValuesFromFifo(){
     accRawVal = getAccRawValuesFromFifo();
-    
+
     correctAccRawValues();
-    
+
     return accRawVal;
 }
 
 xyzFloat MPU9250_WE::getGValuesFromFifo(){
     xyzFloat gVal;
     getCorrectedAccRawValuesFromFifo();
-    
+
     gVal.x = accRawVal.x * accRangeFactor / 16384.0;
     gVal.y = accRawVal.y * accRangeFactor / 16384.0;
     gVal.z = accRawVal.z * accRangeFactor / 16384.0;
@@ -273,7 +273,7 @@ xyzFloat MPU9250_WE::getGValuesFromFifo(){
 float MPU9250_WE::getResultantG(xyzFloat gVal){
     float resultant = 0.0;
     resultant = sqrt(sq(gVal.x) + sq(gVal.y) + sq(gVal.z));
-    
+
     return resultant;
 }
 
@@ -288,11 +288,11 @@ xyzFloat MPU9250_WE::getGyrRawValues(){
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-    
+
     gyrRawVal.x = xRaw * 1.0;
     gyrRawVal.y = yRaw * 1.0;
     gyrRawVal.z = zRaw * 1.0;
-     
+
     return gyrRawVal;
 }
 
@@ -301,55 +301,55 @@ xyzFloat MPU9250_WE::getCorrectedGyrRawValues(){
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-    
+
     gyrRawVal.x = xRaw * 1.0;
     gyrRawVal.y = yRaw * 1.0;
     gyrRawVal.z = zRaw * 1.0;
-     
+
     correctGyrRawValues();
-    
+
     return gyrRawVal;
 }
-    
+
 xyzFloat MPU9250_WE::getGyrValues(){
     xyzFloat gyrVal;
     getCorrectedGyrRawValues();
-    
+
     gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
     gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
     gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
-     
+
     return gyrVal;
 }
 
 xyzFloat MPU9250_WE::getGyrValuesFromFifo(){
     xyzFloat gyrVal;
     gyrRawVal = readMPU9250xyzValFromFifo();
-    
+
     correctGyrRawValues();
     gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
     gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
     gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
-    
-    return gyrVal;  
+
+    return gyrVal;
 }
 
 xyzFloat MPU9250_WE::getMagValues(){
     xyzFloat magVal;
-    
+
     uint64_t xyzDataReg = readAK8963Data();
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-    
+
     magVal.x = xRaw * 4912.0 / 32760.0 * magCorrFactor.x;
     magVal.y = yRaw * 4912.0 / 32760.0 * magCorrFactor.y;
     magVal.z = zRaw * 4912.0 / 32760.0 * magCorrFactor.z;
-    
+
     return magVal;
 }
 
-/********* Power, Sleep, Standby *********/ 
+/********* Power, Sleep, Standby *********/
 
 void MPU9250_WE::sleep(bool sleep){
     regVal = readMPU9250Register8(MPU9250_PWR_MGMT_1);
@@ -384,9 +384,9 @@ void MPU9250_WE::enableGyrStandby(bool gyroStandby){
     writeMPU9250Register(MPU9250_PWR_MGMT_1, regVal);
 }
 
-        
-/******** Angles and Orientation *********/ 
-    
+
+/******** Angles and Orientation *********/
+
 xyzFloat MPU9250_WE::getAngles(){
     xyzFloat angleVal;
     xyzFloat gVal = getGValues();
@@ -397,7 +397,7 @@ xyzFloat MPU9250_WE::getAngles(){
         gVal.x = -1.0;
     }
     angleVal.x = (asin(gVal.x)) * 57.296;
-    
+
     if(gVal.y > 1.0){
         gVal.y = 1.0;
     }
@@ -405,7 +405,7 @@ xyzFloat MPU9250_WE::getAngles(){
         gVal.y = -1.0;
     }
     angleVal.y = (asin(gVal.y)) * 57.296;
-    
+
     if(gVal.z > 1.0){
         gVal.z = 1.0;
     }
@@ -413,7 +413,7 @@ xyzFloat MPU9250_WE::getAngles(){
         gVal.z = -1.0;
     }
     angleVal.z = (asin(gVal.z)) * 57.296;
-    
+
     return angleVal;
 }
 
@@ -429,18 +429,18 @@ MPU9250_orientation MPU9250_WE::getOrientation(){
                 orientation = MPU9250_FLAT_1;
             }
         }
-        else{                         // |y| > 45 
+        else{                         // |y| > 45
             if(angleVal.y > 0){         //  y  > 0
                 orientation = MPU9250_XY;
             }
             else{                       //  y  < 0
-                orientation = MPU9250_XY_1;   
+                orientation = MPU9250_XY_1;
             }
         }
     }
     else{                           // |x| >= 45
         if(angleVal.x > 0){           //  x  >  0
-            orientation = MPU9250_YX;       
+            orientation = MPU9250_YX;
         }
         else{                       //  x  <  0
             orientation = MPU9250_YX_1;
@@ -468,13 +468,13 @@ float MPU9250_WE::getPitch(){
     float pitch = (atan2(angleVal.x, sqrt(abs((angleVal.x*angleVal.y + angleVal.z*angleVal.z))))*180.0)/M_PI;
     return pitch;
 }
-    
+
 float MPU9250_WE::getRoll(){
     xyzFloat angleVal = getAngles();
     float roll = (atan2(angleVal.y, angleVal.z)*180.0)/M_PI;
     return roll;
 }
-    
+
 
 /************** Interrupts ***************/
 
@@ -514,7 +514,7 @@ void MPU9250_WE::enableClearIntByAnyRead(bool clearByAnyRead){
 void MPU9250_WE::enableInterrupt(MPU9250_intType intType){
     regVal = readMPU9250Register8(MPU9250_INT_ENABLE);
     regVal |= intType;
-    writeMPU9250Register(MPU9250_INT_ENABLE, regVal);   
+    writeMPU9250Register(MPU9250_INT_ENABLE, regVal);
 }
 
 void MPU9250_WE::disableInterrupt(MPU9250_intType intType){
@@ -551,7 +551,7 @@ void MPU9250_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCo
 /***************** FIFO ******************/
 
 /* fifo is a byte which defines the data stored in the FIFO
- * It is structured as: 
+ * It is structured as:
  * Bit 7 = TEMP,              Bit 6 = GYRO_X,  Bit 5 = GYRO_Y   Bit 4 = GYRO_Z,
  * Bit 3 = ACCEL (all axes), Bit 2 = SLAVE_2, Bit 1 = SLAVE_1, Bit 0 = SLAVE_0;
  * e.g. 0b11001001 => TEMP, GYRO_X, ACCEL, SLAVE0 are enabled
@@ -596,25 +596,25 @@ void MPU9250_WE::setFifoMode(MPU9250_fifoMode mode){
         regVal &= ~(0x40);
     }
     writeMPU9250Register(MPU9250_CONFIG, regVal);
-    
+
 }
 
 int16_t MPU9250_WE::getNumberOfFifoDataSets(){
     int16_t numberOfSets = getFifoCount();
-        
+
     if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
         numberOfSets /= 6;
     }
     else if(fifoType==MPU9250_FIFO_ACC_GYR){
         numberOfSets /= 12;
     }
-    
+
     return numberOfSets;
 }
 
 void MPU9250_WE::findFifoBegin(){
     int16_t count = getFifoCount();
-        
+
     if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
         if(count > 510){
             for(int i=0; i<2; i++){
@@ -636,7 +636,7 @@ void MPU9250_WE::findFifoBegin(){
 bool MPU9250_WE::initMagnetometer(){
     enableI2CMaster();
     resetMagnetometer();
-    
+
     if(!(whoAmIMag() == AK8963_WHO_AM_I_CODE)){
         return false;
     }
@@ -644,7 +644,7 @@ bool MPU9250_WE::initMagnetometer(){
     getAsaVals();
     setMagnetometer16Bit();
     setMagOpMode(AK8963_CONT_MODE_8HZ);
-  
+
     return true;
 }
 
@@ -669,7 +669,7 @@ void MPU9250_WE::startMagMeasurement(){
     delay(200);
 }
 
-/************************************************ 
+/************************************************
      Private Functions
 *************************************************/
 
@@ -726,13 +726,13 @@ void MPU9250_WE::writeMPU9250Register(uint8_t reg, uint8_t val){
     _wire->write(val);
     _wire->endTransmission();
 }
-  
+
 void MPU9250_WE::writeAK8963Register(uint8_t reg, uint8_t val){
     writeMPU9250Register(MPU9250_I2C_SLV0_ADDR, AK8963_ADDRESS); // write AK8963
     writeMPU9250Register(MPU9250_I2C_SLV0_REG, reg); // define AK8963 register to be written to
     writeMPU9250Register(MPU9250_I2C_SLV0_DO, val);
 }
-  
+
 uint8_t MPU9250_WE::readMPU9250Register8(uint8_t reg){
     uint8_t regValue = 0;
     _wire->beginTransmission(i2cAddress);
@@ -750,15 +750,15 @@ uint8_t MPU9250_WE::readAK8963Register8(uint8_t reg){
     enableMagDataRead(reg, 0x01);
     regVal = readMPU9250Register8(MPU9250_EXT_SLV_SENS_DATA_00);
     enableMagDataRead(AK8963_HXL, 0x08);
-    
+
     return regVal;
 }
 
 
-uint64_t MPU9250_WE::readAK8963Data(){    
+uint64_t MPU9250_WE::readAK8963Data(){
     uint8_t magByte[6];
     uint64_t regValue = 0;
-    
+
     _wire->beginTransmission(i2cAddress);
     _wire->write(MPU9250_EXT_SLV_SENS_DATA_00);
     _wire->endTransmission(false);
@@ -767,11 +767,11 @@ uint64_t MPU9250_WE::readAK8963Data(){
         for(int i=0; i<6; i++){
             magByte[i] = _wire->read();
         }
-    }   
-        
-    regValue = ((uint64_t) magByte[1]<<40) + ((uint64_t) magByte[0]<<32) +((uint64_t) magByte[3]<<24) + 
+    }
+
+    regValue = ((uint64_t) magByte[1]<<40) + ((uint64_t) magByte[0]<<32) +((uint64_t) magByte[3]<<24) +
            + ((uint64_t) magByte[2]<<16) + ((uint64_t) magByte[5]<<8) +  (uint64_t) magByte[4];
-    
+
     return regValue;
 }
 
@@ -790,10 +790,10 @@ int16_t MPU9250_WE::readMPU9250Register16(uint8_t reg){
     return regValue;
 }
 
-uint64_t MPU9250_WE::readMPU9250Register3x16(uint8_t reg){    
-    uint8_t mpu9250Triple[6]; 
+uint64_t MPU9250_WE::readMPU9250Register3x16(uint8_t reg){
+    uint8_t mpu9250Triple[6];
     uint64_t regValue = 0;
-    
+
     _wire->beginTransmission(i2cAddress);
     _wire->write(reg);
     _wire->endTransmission(false);
@@ -803,8 +803,8 @@ uint64_t MPU9250_WE::readMPU9250Register3x16(uint8_t reg){
             mpu9250Triple[i] = _wire->read();
         }
     }
-    
-    regValue = ((uint64_t) mpu9250Triple[0]<<40) + ((uint64_t) mpu9250Triple[1]<<32) +((uint64_t) mpu9250Triple[2]<<24) + 
+
+    regValue = ((uint64_t) mpu9250Triple[0]<<40) + ((uint64_t) mpu9250Triple[1]<<32) +((uint64_t) mpu9250Triple[2]<<24) +
            + ((uint64_t) mpu9250Triple[3]<<16) + ((uint64_t) mpu9250Triple[4]<<8) +  (uint64_t) mpu9250Triple[5];
     return regValue;
 }
@@ -812,7 +812,7 @@ uint64_t MPU9250_WE::readMPU9250Register3x16(uint8_t reg){
 xyzFloat MPU9250_WE::readMPU9250xyzValFromFifo(){
     uint8_t fifoTriple[6];
     xyzFloat xyzResult = {0.0, 0.0, 0.0};
-      
+
     _wire->beginTransmission(i2cAddress);
     _wire->write(MPU9250_FIFO_R_W);
     _wire->endTransmission(false);
@@ -822,12 +822,12 @@ xyzFloat MPU9250_WE::readMPU9250xyzValFromFifo(){
             fifoTriple[i] = _wire->read();
         }
     }
-        
+
     xyzResult.x = ((int16_t)((fifoTriple[0]<<8) + fifoTriple[1])) * 1.0;
     xyzResult.y = ((int16_t)((fifoTriple[2]<<8) + fifoTriple[3])) * 1.0;
     xyzResult.z = ((int16_t)((fifoTriple[4]<<8) + fifoTriple[5])) * 1.0;
-    
-    return xyzResult; 
+
+    return xyzResult;
 }
 
 void MPU9250_WE::setMagnetometer16Bit(){

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -95,19 +95,12 @@ void MPU9250_WE::autoOffsets(){
     delay(100);
 
     for(int i=0; i<50; i++){
+        // acceleration
         getAccRawValues();
         accOffsetVal.x += accRawVal.x;
         accOffsetVal.y += accRawVal.y;
         accOffsetVal.z += accRawVal.z;
-        delay(1);
-    }
-
-    accOffsetVal.x /= 50;
-    accOffsetVal.y /= 50;
-    accOffsetVal.z /= 50;
-    accOffsetVal.z -= 16384.0;
-
-    for(int i=0; i<50; i++){
+        // gyro
         getGyrRawValues();
         gyrOffsetVal.x += gyrRawVal.x;
         gyrOffsetVal.y += gyrRawVal.y;
@@ -115,6 +108,12 @@ void MPU9250_WE::autoOffsets(){
         delay(1);
     }
 
+    // acceleration
+    accOffsetVal.x /= 50;
+    accOffsetVal.y /= 50;
+    accOffsetVal.z /= 50;
+    accOffsetVal.z -= 16384.0;
+    // gyro
     gyrOffsetVal.x /= 50;
     gyrOffsetVal.y /= 50;
     gyrOffsetVal.z /= 50;

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -19,6 +19,34 @@
 
 #include "MPU9250_WE.h"
 
+
+/* Registers AK8963 */
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_WIA         ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_INFO        ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_STATUS_1    ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_HXL         ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_HYL         ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_HZL         ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_STATUS_2    ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_CNTL_1      ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_CNTL_2      ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_ASTC        ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_I2CDIS      ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_ASAX        ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_ASAY        ;
+uint8_t constexpr MPU9250_WE::REGISTER_AK8963_ASAZ        ;
+
+/* Register Values */
+uint8_t constexpr MPU9250_WE::REGISTER_VALUE_AK8963_16_BIT;
+uint8_t constexpr MPU9250_WE::REGISTER_VALUE_AK8963_OVF   ;
+uint8_t constexpr MPU9250_WE::REGISTER_VALUE_AK8963_READ  ;
+
+/* Others */
+uint8_t constexpr MPU9250_WE::WHO_AM_I_CODE               ;
+uint8_t constexpr MPU9250_WE::MAGNETOMETER_I2C_ADDRESS    ;
+uint8_t constexpr MPU9250_WE::MAGNETOMETER_WHO_AM_I_CODE  ;
+
+
 /************  Constructors ************/
 
 MPU9250_WE::MPU9250_WE(int addr)

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -43,17 +43,17 @@ MPU9250_WE::MPU9250_WE(TwoWire *w){
 
 
 /************ Basic Settings ************/
-    
 
-bool MPU9250_WE::init(){ 
+
+bool MPU9250_WE::init(uint8_t const expectedValue){
     reset_MPU9250();
     delay(10);
     writeMPU9250Register(MPU9250_INT_PIN_CFG, MPU9250_BYPASS_EN);  // Bypass Enable
     delay(10);
-    if(whoAmI() != MPU9250_WHO_AM_I_CODE){
+    if(whoAmI() != expectedValue){
         return false;
     }
-    
+
     accOffsetVal.x = 0.0;
     accOffsetVal.y = 0.0;
     accOffsetVal.z = 0.0;
@@ -64,8 +64,13 @@ bool MPU9250_WE::init(){
     gyrRangeFactor = 1;
     fifoType = MPU9250_FIFO_ACC;
     sleep(false);
-    
+
     return true;
+}
+
+
+bool MPU9250_WE::init(){
+    return init(MPU9250_WHO_AM_I_CODE);
 }
 
 uint8_t MPU9250_WE::whoAmI(){

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -85,14 +85,16 @@ bool MPU9250_WE::init(){
 xyzFloat MPU9250_WE::getMagValues(){
     xyzFloat magVal;
 
-    uint64_t xyzDataReg = readAK8963Data();
+    uint64_t const xyzDataReg = readAK8963Data();
     int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
     int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
     int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
 
-    magVal.x = xRaw * 4912.0 / 32760.0 * magCorrFactor.x;
-    magVal.y = yRaw * 4912.0 / 32760.0 * magCorrFactor.y;
-    magVal.z = zRaw * 4912.0 / 32760.0 * magCorrFactor.z;
+    float constexpr scaleFactor = 4912.0 / 32760.0;
+
+    magVal.x = xRaw * scaleFactor * magCorrFactor.x;
+    magVal.y = yRaw * scaleFactor * magCorrFactor.y;
+    magVal.z = zRaw * scaleFactor * magCorrFactor.z;
 
     return magVal;
 }

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -21,321 +21,38 @@
 
 /************  Constructors ************/
 
-MPU9250_WE::MPU9250_WE(int addr){
-    _wire = &Wire;
-    i2cAddress = addr;
+MPU9250_WE::MPU9250_WE(int addr)
+    : MPU6500_WE(addr)
+{
+    // intentionally empty
 }
 
-MPU9250_WE::MPU9250_WE(){
-    _wire = &Wire;
-    i2cAddress = 0x68;
+MPU9250_WE::MPU9250_WE()
+    : MPU6500_WE()
+{
+    // intentionally empty
 }
 
-MPU9250_WE::MPU9250_WE(TwoWire *w, int addr){
-    _wire = w;
-    i2cAddress = addr;
+MPU9250_WE::MPU9250_WE(TwoWire *w, int addr)
+    : MPU6500_WE(w, addr)
+{
+    // intentionally empty
 }
 
-MPU9250_WE::MPU9250_WE(TwoWire *w){
-    _wire = w;
-    i2cAddress = 0x68;
+MPU9250_WE::MPU9250_WE(TwoWire *w)
+    : MPU6500_WE(w)
+{
+    // intentionally empty
 }
 
 
 /************ Basic Settings ************/
 
-
-bool MPU9250_WE::init(uint8_t const expectedValue){
-    reset_MPU9250();
-    delay(10);
-    writeMPU9250Register(MPU9250_INT_PIN_CFG, MPU9250_BYPASS_EN);  // Bypass Enable
-    delay(10);
-    if(whoAmI() != expectedValue){
-        return false;
-    }
-
-    accOffsetVal.x = 0.0;
-    accOffsetVal.y = 0.0;
-    accOffsetVal.z = 0.0;
-    accRangeFactor = 1;
-    gyrOffsetVal.x = 0.0;
-    gyrOffsetVal.y = 0.0;
-    gyrOffsetVal.z = 0.0;
-    gyrRangeFactor = 1;
-    fifoType = MPU9250_FIFO_ACC;
-    sleep(false);
-
-    return true;
-}
-
-
 bool MPU9250_WE::init(){
-    return init(MPU9250_WHO_AM_I_CODE);
-}
-
-uint8_t MPU9250_WE::whoAmI(){
-    return readMPU9250Register8(MPU9250_WHO_AM_I);
-}
-
-void MPU9250_WE::autoOffsets(){
-    accOffsetVal.x = 0.0;
-    accOffsetVal.y = 0.0;
-    accOffsetVal.z = 0.0;
-
-    gyrOffsetVal.x = 0.0;
-    gyrOffsetVal.y = 0.0;
-    gyrOffsetVal.z = 0.0;
-
-    enableGyrDLPF();
-    setGyrDLPF(MPU9250_DLPF_6);  // lowest noise
-    setGyrRange(MPU9250_GYRO_RANGE_250); // highest resolution
-    setAccRange(MPU9250_ACC_RANGE_2G);
-    enableAccDLPF(true);
-    setAccDLPF(MPU9250_DLPF_6);
-    delay(100);
-
-    for(int i=0; i<50; i++){
-        // acceleration
-        getAccRawValues();
-        accOffsetVal.x += accRawVal.x;
-        accOffsetVal.y += accRawVal.y;
-        accOffsetVal.z += accRawVal.z;
-        // gyro
-        getGyrRawValues();
-        gyrOffsetVal.x += gyrRawVal.x;
-        gyrOffsetVal.y += gyrRawVal.y;
-        gyrOffsetVal.z += gyrRawVal.z;
-        delay(1);
-    }
-
-    // acceleration
-    accOffsetVal.x /= 50;
-    accOffsetVal.y /= 50;
-    accOffsetVal.z /= 50;
-    accOffsetVal.z -= 16384.0;
-    // gyro
-    gyrOffsetVal.x /= 50;
-    gyrOffsetVal.y /= 50;
-    gyrOffsetVal.z /= 50;
-
-}
-
-void MPU9250_WE::setAccOffsets(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax){
-    accOffsetVal.x = (xMax + xMin) * 0.5;
-    accOffsetVal.y = (yMax + yMin) * 0.5;
-    accOffsetVal.z = (zMax + zMin) * 0.5;
-}
-
-void MPU9250_WE::setGyrOffsets(float xOffset, float yOffset, float zOffset){
-    gyrOffsetVal.x = xOffset;
-    gyrOffsetVal.y = yOffset;
-    gyrOffsetVal.z = zOffset;
-}
-
-void MPU9250_WE::setGyrDLPF(MPU9250_dlpf dlpf){
-    regVal = readMPU9250Register8(MPU9250_CONFIG);
-    regVal &= 0xF8;
-    regVal |= dlpf;
-    writeMPU9250Register(MPU9250_CONFIG, regVal);
-}
-
-void MPU9250_WE::setSampleRateDivider(uint8_t splRateDiv){
-    writeMPU9250Register(MPU9250_SMPLRT_DIV, splRateDiv);
-}
-
-void MPU9250_WE::setGyrRange(MPU9250_gyroRange gyroRange){
-    regVal = readMPU9250Register8(MPU9250_GYRO_CONFIG);
-    regVal &= 0xE7;
-    regVal |= (gyroRange<<3);
-    writeMPU9250Register(MPU9250_GYRO_CONFIG, regVal);
-    gyrRangeFactor = (1<<gyroRange);
-}
-
-void MPU9250_WE::enableGyrDLPF(){
-    regVal = readMPU9250Register8(MPU9250_GYRO_CONFIG);
-    regVal &= 0xFC;
-    writeMPU9250Register(MPU9250_GYRO_CONFIG, regVal);
-}
-
-void MPU9250_WE::disableGyrDLPF(MPU9250_bw_wo_dlpf bw){
-    regVal = readMPU9250Register8(MPU9250_GYRO_CONFIG);
-    regVal &= 0xFC;
-    regVal |= bw;
-    writeMPU9250Register(MPU9250_GYRO_CONFIG, regVal);
-}
-
-void MPU9250_WE::setAccRange(MPU9250_accRange accRange){
-    regVal = readMPU9250Register8(MPU9250_ACCEL_CONFIG);
-    regVal &= 0xE7;
-    regVal |= (accRange<<3);
-    writeMPU9250Register(MPU9250_ACCEL_CONFIG, regVal);
-    accRangeFactor = 1<<accRange;
-}
-
-void MPU9250_WE::enableAccDLPF(bool enable){
-    regVal = readMPU9250Register8(MPU9250_ACCEL_CONFIG_2);
-    if(enable){
-        regVal &= ~8;
-    }
-    else{
-        regVal |= 8;
-    }
-    writeMPU9250Register(MPU9250_ACCEL_CONFIG_2, regVal);
-}
-
-void MPU9250_WE::setAccDLPF(MPU9250_dlpf dlpf){
-    regVal = readMPU9250Register8(MPU9250_ACCEL_CONFIG_2);
-    regVal &= 0xF8;
-    regVal |= dlpf;
-    writeMPU9250Register(MPU9250_ACCEL_CONFIG_2, regVal);
-}
-
-void MPU9250_WE::setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr){
-    writeMPU9250Register(MPU9250_LP_ACCEL_ODR, lpaodr);
-}
-
-void MPU9250_WE::enableAccAxes(MPU9250_xyzEn enable){
-    regVal = readMPU9250Register8(MPU9250_PWR_MGMT_2);
-    regVal &= ~(0x38);
-    regVal |= (enable<<3);
-    writeMPU9250Register(MPU9250_PWR_MGMT_2, regVal);
-}
-
-void MPU9250_WE::enableGyrAxes(MPU9250_xyzEn enable){
-    regVal = readMPU9250Register8(MPU9250_PWR_MGMT_2);
-    regVal &= ~(0x07);
-    regVal |= enable;
-    writeMPU9250Register(MPU9250_PWR_MGMT_2, regVal);
+    return MPU6500_WE::init(MPU9250_WHO_AM_I_CODE);
 }
 
 /************* x,y,z results *************/
-
-xyzFloat MPU9250_WE::getAccRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU9250_ACCEL_OUT);
-    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
-    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
-    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-
-    accRawVal.x = xRaw * 1.0;
-    accRawVal.y = yRaw * 1.0;
-    accRawVal.z = zRaw * 1.0;
-
-    return accRawVal;
-}
-
-xyzFloat MPU9250_WE::getCorrectedAccRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU9250_ACCEL_OUT);
-    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
-    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
-    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-
-    accRawVal.x = xRaw * 1.0;
-    accRawVal.y = yRaw * 1.0;
-    accRawVal.z = zRaw * 1.0;
-
-    correctAccRawValues();
-
-    return accRawVal;
-}
-
-xyzFloat MPU9250_WE::getGValues(){
-    xyzFloat gVal;
-    getCorrectedAccRawValues();
-
-    gVal.x = accRawVal.x * accRangeFactor / 16384.0;
-    gVal.y = accRawVal.y * accRangeFactor / 16384.0;
-    gVal.z = accRawVal.z * accRangeFactor / 16384.0;
-    return gVal;
-}
-
-xyzFloat MPU9250_WE::getAccRawValuesFromFifo(){
-    xyzFloat accRawVal = readMPU9250xyzValFromFifo();
-    return accRawVal;
-}
-
-xyzFloat MPU9250_WE::getCorrectedAccRawValuesFromFifo(){
-    accRawVal = getAccRawValuesFromFifo();
-
-    correctAccRawValues();
-
-    return accRawVal;
-}
-
-xyzFloat MPU9250_WE::getGValuesFromFifo(){
-    xyzFloat gVal;
-    getCorrectedAccRawValuesFromFifo();
-
-    gVal.x = accRawVal.x * accRangeFactor / 16384.0;
-    gVal.y = accRawVal.y * accRangeFactor / 16384.0;
-    gVal.z = accRawVal.z * accRangeFactor / 16384.0;
-    return gVal;
-}
-
-
-
-float MPU9250_WE::getResultantG(xyzFloat gVal){
-    float resultant = 0.0;
-    resultant = sqrt(sq(gVal.x) + sq(gVal.y) + sq(gVal.z));
-
-    return resultant;
-}
-
-float MPU9250_WE::getTemperature(){
-    int16_t regVal16 = readMPU9250Register16(MPU9250_TEMP_OUT);
-    float tmp = (regVal16*1.0 - MPU9250_ROOM_TEMP_OFFSET)/MPU9250_T_SENSITIVITY + 21.0;
-    return tmp;
-}
-
-xyzFloat MPU9250_WE::getGyrRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU9250_GYRO_OUT);
-    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
-    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
-    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-
-    gyrRawVal.x = xRaw * 1.0;
-    gyrRawVal.y = yRaw * 1.0;
-    gyrRawVal.z = zRaw * 1.0;
-
-    return gyrRawVal;
-}
-
-xyzFloat MPU9250_WE::getCorrectedGyrRawValues(){
-    uint64_t xyzDataReg = readMPU9250Register3x16(MPU9250_GYRO_OUT);
-    int16_t xRaw = (int16_t)((xyzDataReg >> 32) & 0xFFFF);
-    int16_t yRaw = (int16_t)((xyzDataReg >> 16) & 0xFFFF);
-    int16_t zRaw = (int16_t)(xyzDataReg & 0xFFFF);
-
-    gyrRawVal.x = xRaw * 1.0;
-    gyrRawVal.y = yRaw * 1.0;
-    gyrRawVal.z = zRaw * 1.0;
-
-    correctGyrRawValues();
-
-    return gyrRawVal;
-}
-
-xyzFloat MPU9250_WE::getGyrValues(){
-    xyzFloat gyrVal;
-    getCorrectedGyrRawValues();
-
-    gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
-    gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
-    gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
-
-    return gyrVal;
-}
-
-xyzFloat MPU9250_WE::getGyrValuesFromFifo(){
-    xyzFloat gyrVal;
-    gyrRawVal = readMPU9250xyzValFromFifo();
-
-    correctGyrRawValues();
-    gyrVal.x = gyrRawVal.x * gyrRangeFactor * 250.0 / 32768.0;
-    gyrVal.y = gyrRawVal.y * gyrRangeFactor * 250.0 / 32768.0;
-    gyrVal.z = gyrRawVal.z * gyrRangeFactor * 250.0 / 32768.0;
-
-    return gyrVal;
-}
 
 xyzFloat MPU9250_WE::getMagValues(){
     xyzFloat magVal;
@@ -350,288 +67,6 @@ xyzFloat MPU9250_WE::getMagValues(){
     magVal.z = zRaw * 4912.0 / 32760.0 * magCorrFactor.z;
 
     return magVal;
-}
-
-/********* Power, Sleep, Standby *********/
-
-void MPU9250_WE::sleep(bool sleep){
-    regVal = readMPU9250Register8(MPU9250_PWR_MGMT_1);
-    if(sleep){
-        regVal |= 0x40;
-    }
-    else{
-        regVal &= ~(0x40);
-    }
-    writeMPU9250Register(MPU9250_PWR_MGMT_1, regVal);
-}
-
-void MPU9250_WE::enableCycle(bool cycle){
-    regVal = readMPU9250Register8(MPU9250_PWR_MGMT_1);
-    if(cycle){
-        regVal |= 0x20;
-    }
-    else{
-        regVal &= ~(0x20);
-    }
-    writeMPU9250Register(MPU9250_PWR_MGMT_1, regVal);
-}
-
-void MPU9250_WE::enableGyrStandby(bool gyroStandby){
-    regVal = readMPU9250Register8(MPU9250_PWR_MGMT_1);
-    if(gyroStandby){
-        regVal |= 0x10;
-    }
-    else{
-        regVal &= ~(0x10);
-    }
-    writeMPU9250Register(MPU9250_PWR_MGMT_1, regVal);
-}
-
-
-/******** Angles and Orientation *********/
-
-xyzFloat MPU9250_WE::getAngles(){
-    xyzFloat angleVal;
-    xyzFloat gVal = getGValues();
-    if(gVal.x > 1.0){
-        gVal.x = 1.0;
-    }
-    else if(gVal.x < -1.0){
-        gVal.x = -1.0;
-    }
-    angleVal.x = (asin(gVal.x)) * 57.296;
-
-    if(gVal.y > 1.0){
-        gVal.y = 1.0;
-    }
-    else if(gVal.y < -1.0){
-        gVal.y = -1.0;
-    }
-    angleVal.y = (asin(gVal.y)) * 57.296;
-
-    if(gVal.z > 1.0){
-        gVal.z = 1.0;
-    }
-    else if(gVal.z < -1.0){
-        gVal.z = -1.0;
-    }
-    angleVal.z = (asin(gVal.z)) * 57.296;
-
-    return angleVal;
-}
-
-MPU9250_orientation MPU9250_WE::getOrientation(){
-    xyzFloat angleVal = getAngles();
-    MPU9250_orientation orientation = MPU9250_FLAT;
-    if(abs(angleVal.x) < 45){      // |x| < 45
-        if(abs(angleVal.y) < 45){      // |y| < 45
-            if(angleVal.z > 0){          //  z  > 0
-                orientation = MPU9250_FLAT;
-            }
-            else{                        //  z  < 0
-                orientation = MPU9250_FLAT_1;
-            }
-        }
-        else{                         // |y| > 45
-            if(angleVal.y > 0){         //  y  > 0
-                orientation = MPU9250_XY;
-            }
-            else{                       //  y  < 0
-                orientation = MPU9250_XY_1;
-            }
-        }
-    }
-    else{                           // |x| >= 45
-        if(angleVal.x > 0){           //  x  >  0
-            orientation = MPU9250_YX;
-        }
-        else{                       //  x  <  0
-            orientation = MPU9250_YX_1;
-        }
-    }
-    return orientation;
-}
-
-String MPU9250_WE::getOrientationAsString(){
-    MPU9250_orientation orientation = getOrientation();
-    String orientationAsString = "";
-    switch(orientation){
-        case MPU9250_FLAT:      orientationAsString = "z up";   break;
-        case MPU9250_FLAT_1:    orientationAsString = "z down"; break;
-        case MPU9250_XY:        orientationAsString = "y up";   break;
-        case MPU9250_XY_1:      orientationAsString = "y down"; break;
-        case MPU9250_YX:        orientationAsString = "x up";   break;
-        case MPU9250_YX_1:      orientationAsString = "x down"; break;
-    }
-    return orientationAsString;
-}
-
-float MPU9250_WE::getPitch(){
-    xyzFloat angleVal = getAngles();
-    float pitch = (atan2(angleVal.x, sqrt(abs((angleVal.x*angleVal.y + angleVal.z*angleVal.z))))*180.0)/M_PI;
-    return pitch;
-}
-
-float MPU9250_WE::getRoll(){
-    xyzFloat angleVal = getAngles();
-    float roll = (atan2(angleVal.y, angleVal.z)*180.0)/M_PI;
-    return roll;
-}
-
-
-/************** Interrupts ***************/
-
-void MPU9250_WE::setIntPinPolarity(MPU9250_intPinPol pol){
-    regVal = readMPU9250Register8(MPU9250_INT_PIN_CFG);
-    if(pol){
-        regVal |= 0x80;
-    }
-    else{
-        regVal &= ~(0x80);
-    }
-    writeMPU9250Register(MPU9250_INT_PIN_CFG, regVal);
-}
-
-void MPU9250_WE::enableIntLatch(bool latch){
-    regVal = readMPU9250Register8(MPU9250_INT_PIN_CFG);
-    if(latch){
-        regVal |= 0x20;
-    }
-    else{
-        regVal &= ~(0x20);
-    }
-    writeMPU9250Register(MPU9250_INT_PIN_CFG, regVal);
-}
-
-void MPU9250_WE::enableClearIntByAnyRead(bool clearByAnyRead){
-    regVal = readMPU9250Register8(MPU9250_INT_PIN_CFG);
-    if(clearByAnyRead){
-        regVal |= 0x10;
-    }
-    else{
-        regVal &= ~(0x10);
-    }
-    writeMPU9250Register(MPU9250_INT_PIN_CFG, regVal);
-}
-
-void MPU9250_WE::enableInterrupt(MPU9250_intType intType){
-    regVal = readMPU9250Register8(MPU9250_INT_ENABLE);
-    regVal |= intType;
-    writeMPU9250Register(MPU9250_INT_ENABLE, regVal);
-}
-
-void MPU9250_WE::disableInterrupt(MPU9250_intType intType){
-    regVal = readMPU9250Register8(MPU9250_INT_ENABLE);
-    regVal &= ~intType;
-    writeMPU9250Register(MPU9250_INT_ENABLE, regVal);
-}
-
-bool MPU9250_WE::checkInterrupt(uint8_t source, MPU9250_intType type){
-    source &= type;
-    return source;
-}
-
-uint8_t MPU9250_WE::readAndClearInterrupts(){
-    regVal = readMPU9250Register8(MPU9250_INT_STATUS);
-    return regVal;
-}
-
-void MPU9250_WE::setWakeOnMotionThreshold(uint8_t womthresh){
-    writeMPU9250Register(MPU9250_WOM_THR, womthresh);
-}
-
-void MPU9250_WE::enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn){
-    regVal = 0;
-    if(womEn){
-        regVal |= 0x80;
-    }
-    if(womCompEn){
-        regVal |= 0x40;
-    }
-    writeMPU9250Register(MPU9250_MOT_DET_CTRL, regVal);
-}
-
-/***************** FIFO ******************/
-
-/* fifo is a byte which defines the data stored in the FIFO
- * It is structured as:
- * Bit 7 = TEMP,              Bit 6 = GYRO_X,  Bit 5 = GYRO_Y   Bit 4 = GYRO_Z,
- * Bit 3 = ACCEL (all axes), Bit 2 = SLAVE_2, Bit 1 = SLAVE_1, Bit 0 = SLAVE_0;
- * e.g. 0b11001001 => TEMP, GYRO_X, ACCEL, SLAVE0 are enabled
- */
-void MPU9250_WE::startFifo(MPU9250_fifo_type fifo){
-    fifoType = fifo;
-    writeMPU9250Register(MPU9250_FIFO_EN, fifoType);
-}
-
-void MPU9250_WE::stopFifo(){
-    writeMPU9250Register(MPU9250_FIFO_EN, 0);
-}
-
-void MPU9250_WE::enableFifo(bool fifo){
-    regVal = readMPU9250Register8(MPU9250_USER_CTRL);
-    if(fifo){
-        regVal |= 0x40;
-    }
-    else{
-        regVal &= ~(0x40);
-    }
-    writeMPU9250Register(MPU9250_USER_CTRL, regVal);
-}
-
-void MPU9250_WE::resetFifo(){
-    regVal = readMPU9250Register8(MPU9250_USER_CTRL);
-    regVal |= 0x04;
-    writeMPU9250Register(MPU9250_USER_CTRL, regVal);
-}
-
-int16_t MPU9250_WE::getFifoCount(){
-    uint16_t regVal16 = (uint16_t) readMPU9250Register16(MPU9250_FIFO_COUNT);
-    return regVal16;
-}
-
-void MPU9250_WE::setFifoMode(MPU9250_fifoMode mode){
-    regVal = readMPU9250Register8(MPU9250_CONFIG);
-    if(mode){
-        regVal |= 0x40;
-    }
-    else{
-        regVal &= ~(0x40);
-    }
-    writeMPU9250Register(MPU9250_CONFIG, regVal);
-
-}
-
-int16_t MPU9250_WE::getNumberOfFifoDataSets(){
-    int16_t numberOfSets = getFifoCount();
-
-    if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
-        numberOfSets /= 6;
-    }
-    else if(fifoType==MPU9250_FIFO_ACC_GYR){
-        numberOfSets /= 12;
-    }
-
-    return numberOfSets;
-}
-
-void MPU9250_WE::findFifoBegin(){
-    int16_t count = getFifoCount();
-
-    if((fifoType == MPU9250_FIFO_ACC) || (fifoType == MPU9250_FIFO_GYR)){
-        if(count > 510){
-            for(int i=0; i<2; i++){
-                readMPU9250Register8(MPU9250_FIFO_R_W);
-            }
-        }
-    }
-    else if(fifoType==MPU9250_FIFO_ACC_GYR){
-        if(count > 504){
-            for(int i=0; i<8; i++){
-                readMPU9250Register8(MPU9250_FIFO_R_W);
-            }
-        }
-    }
 }
 
 /************** Magnetometer **************/
@@ -652,13 +87,11 @@ bool MPU9250_WE::initMagnetometer(){
 }
 
 uint8_t MPU9250_WE::whoAmIMag(){
-    regVal = 0;
-    regVal = readAK8963Register8(AK8963_WIA);
-    return regVal;
+    return readAK8963Register8(AK8963_WIA);
 }
 
 void MPU9250_WE::setMagOpMode(AK8963_opMode opMode){
-    regVal = readAK8963Register8(AK8963_CNTL_1);
+    uint8_t regVal = readAK8963Register8(AK8963_CNTL_1);
     regVal &= 0xF0;
     regVal |= opMode;
     writeAK8963Register(AK8963_CNTL_1, regVal);
@@ -675,31 +108,6 @@ void MPU9250_WE::startMagMeasurement(){
 /************************************************
      Private Functions
 *************************************************/
-
-void MPU9250_WE::correctAccRawValues(){
-    accRawVal.x -= (accOffsetVal.x / accRangeFactor);
-    accRawVal.y -= (accOffsetVal.y / accRangeFactor);
-    accRawVal.z -= (accOffsetVal.z / accRangeFactor);
-}
-
-void MPU9250_WE::correctGyrRawValues(){
-    gyrRawVal.x -= (gyrOffsetVal.x / gyrRangeFactor);
-    gyrRawVal.y -= (gyrOffsetVal.y / gyrRangeFactor);
-    gyrRawVal.z -= (gyrOffsetVal.z / gyrRangeFactor);
-}
-
-void MPU9250_WE::reset_MPU9250(){
-    writeMPU9250Register(MPU9250_PWR_MGMT_1, MPU9250_RESET);
-    delay(10);  // wait for registers to reset
-}
-
-void MPU9250_WE::enableI2CMaster(){
-    regVal = readMPU9250Register8(MPU9250_USER_CTRL);
-    regVal |= MPU9250_I2C_MST_EN;
-    writeMPU9250Register(MPU9250_USER_CTRL, regVal); //enable I2C master
-    writeMPU9250Register(MPU9250_I2C_MST_CTRL, 0x00); // set I2C clock to 400 kHz
-    delay(10);
-}
 
 void MPU9250_WE::enableMagDataRead(uint8_t reg, uint8_t bytes){
     writeMPU9250Register(MPU9250_I2C_SLV0_ADDR, AK8963_ADDRESS | AK8963_READ); // read AK8963
@@ -723,40 +131,19 @@ void MPU9250_WE::getAsaVals(){
     magCorrFactor.z = (0.5 * (rawCorr-128)/128.0) + 1.0;
 }
 
-void MPU9250_WE::writeMPU9250Register(uint8_t reg, uint8_t val){
-    _wire->beginTransmission(i2cAddress);
-    _wire->write(reg);
-    _wire->write(val);
-    _wire->endTransmission();
-}
-
 void MPU9250_WE::writeAK8963Register(uint8_t reg, uint8_t val){
     writeMPU9250Register(MPU9250_I2C_SLV0_ADDR, AK8963_ADDRESS); // write AK8963
     writeMPU9250Register(MPU9250_I2C_SLV0_REG, reg); // define AK8963 register to be written to
     writeMPU9250Register(MPU9250_I2C_SLV0_DO, val);
 }
 
-uint8_t MPU9250_WE::readMPU9250Register8(uint8_t reg){
-    uint8_t regValue = 0;
-    _wire->beginTransmission(i2cAddress);
-    _wire->write(reg);
-    _wire->endTransmission(false);
-    _wire->requestFrom(i2cAddress,1);
-    if(_wire->available()){
-        regValue = _wire->read();
-    }
-    return regValue;
-}
-
-
 uint8_t MPU9250_WE::readAK8963Register8(uint8_t reg){
     enableMagDataRead(reg, 0x01);
-    regVal = readMPU9250Register8(MPU9250_EXT_SLV_SENS_DATA_00);
+    uint8_t const regVal = readMPU9250Register8(MPU9250_EXT_SLV_SENS_DATA_00);
     enableMagDataRead(AK8963_HXL, 0x08);
 
     return regVal;
 }
-
 
 uint64_t MPU9250_WE::readAK8963Data(){
     uint8_t magByte[6];
@@ -778,70 +165,14 @@ uint64_t MPU9250_WE::readAK8963Data(){
     return regValue;
 }
 
-int16_t MPU9250_WE::readMPU9250Register16(uint8_t reg){
-    uint8_t MSByte = 0, LSByte = 0;
-    int16_t regValue = 0;
-    _wire->beginTransmission(i2cAddress);
-    _wire->write(reg);
-    _wire->endTransmission(false);
-    _wire->requestFrom(i2cAddress,2);
-    if(_wire->available()){
-        MSByte = _wire->read();
-        LSByte = _wire->read();
-    }
-    regValue = (MSByte<<8) + LSByte;
-    return regValue;
-}
-
-uint64_t MPU9250_WE::readMPU9250Register3x16(uint8_t reg){
-    uint8_t mpu9250Triple[6];
-    uint64_t regValue = 0;
-
-    _wire->beginTransmission(i2cAddress);
-    _wire->write(reg);
-    _wire->endTransmission(false);
-    _wire->requestFrom(i2cAddress,6);
-    if(_wire->available()){
-        for(int i=0; i<6; i++){
-            mpu9250Triple[i] = _wire->read();
-        }
-    }
-
-    regValue = ((uint64_t) mpu9250Triple[0]<<40) + ((uint64_t) mpu9250Triple[1]<<32) +((uint64_t) mpu9250Triple[2]<<24) +
-           + ((uint64_t) mpu9250Triple[3]<<16) + ((uint64_t) mpu9250Triple[4]<<8) +  (uint64_t) mpu9250Triple[5];
-    return regValue;
-}
-
-xyzFloat MPU9250_WE::readMPU9250xyzValFromFifo(){
-    uint8_t fifoTriple[6];
-    xyzFloat xyzResult = {0.0, 0.0, 0.0};
-
-    _wire->beginTransmission(i2cAddress);
-    _wire->write(MPU9250_FIFO_R_W);
-    _wire->endTransmission(false);
-    _wire->requestFrom(i2cAddress,6);
-    if(_wire->available()){
-        for(int i=0; i<6; i++){
-            fifoTriple[i] = _wire->read();
-        }
-    }
-
-    xyzResult.x = ((int16_t)((fifoTriple[0]<<8) + fifoTriple[1])) * 1.0;
-    xyzResult.y = ((int16_t)((fifoTriple[2]<<8) + fifoTriple[3])) * 1.0;
-    xyzResult.z = ((int16_t)((fifoTriple[4]<<8) + fifoTriple[5])) * 1.0;
-
-    return xyzResult;
-}
-
 void MPU9250_WE::setMagnetometer16Bit(){
-    regVal = readAK8963Register8(AK8963_CNTL_1);
+    uint8_t regVal = readAK8963Register8(AK8963_CNTL_1);
     regVal |= AK8963_16_BIT;
     writeAK8963Register(AK8963_CNTL_1, regVal);
 }
 
 uint8_t MPU9250_WE::getStatus2Register(){
-    regVal = readAK8963Register8(AK8963_STATUS_2);
-    return regVal;
+    return readAK8963Register8(AK8963_STATUS_2);
 }
 
 

--- a/src/MPU9250_WE.cpp
+++ b/src/MPU9250_WE.cpp
@@ -82,6 +82,10 @@ void MPU9250_WE::autoOffsets(){
     accOffsetVal.y = 0.0;
     accOffsetVal.z = 0.0;
 
+    gyrOffsetVal.x = 0.0;
+    gyrOffsetVal.y = 0.0;
+    gyrOffsetVal.z = 0.0;
+
     enableGyrDLPF();
     setGyrDLPF(MPU9250_DLPF_6);  // lowest noise
     setGyrRange(MPU9250_GYRO_RANGE_250); // highest resolution

--- a/src/MPU9250_WE.h
+++ b/src/MPU9250_WE.h
@@ -281,14 +281,18 @@ public:
     void setFifoMode(MPU9250_fifoMode mode);
     int16_t getNumberOfFifoDataSets();
     void findFifoBegin();
-    
+
     /* Magnetometer */
-    
+
     bool initMagnetometer();
     uint8_t whoAmIMag();
     void setMagOpMode(AK8963_opMode opMode);
     void startMagMeasurement();
-       
+
+protected:
+
+    bool init(uint8_t const expectedValue);
+
 private:
     TwoWire *_wire;
     int i2cAddress;

--- a/src/MPU9250_WE.h
+++ b/src/MPU9250_WE.h
@@ -2,33 +2,27 @@
  *
  * This is a library for the 9-axis gyroscope, accelerometer and magnetometer MPU9250.
  *
- * You'll find several example sketches which should enable you to use the library. 
+ * You'll find several example sketches which should enable you to use the library.
  *
  * You are free to use it, change it or build on it. In case you like it, it would
  * be cool if you give it a star.
  *
  * If you find bugs, please inform me!
- * 
+ *
  * Written by Wolfgang (Wolle) Ewald
  *
  * For further information visit my blog:
  *
  * https://wolles-elektronikkiste.de/mpu9250-9-achsen-sensormodul-teil-1  (German)
- * https://wolles-elektronikkiste.de/en/mpu9250-9-axis-sensor-module-part-1  (English) 
+ * https://wolles-elektronikkiste.de/en/mpu9250-9-axis-sensor-module-part-1  (English)
  *
- * 
+ *
  ******************************************************************************/
 
 #ifndef MPU9250_WE_H_
 #define MPU9250_WE_H_
 
-#if (ARDUINO >= 100)
- #include "Arduino.h"
-#else
- #include "WProgram.h"
-#endif
-
-#include <Wire.h>
+#include "MPU6500_WE.h"
 
 #define AK8963_ADDRESS 0x0C
 
@@ -78,14 +72,14 @@
 #define MPU9250_XA_OFFSET_H         0x77
 #define MPU9250_XA_OFFSET_L         0x78
 #define MPU9250_YA_OFFSET_H         0x7A
-#define MPU9250_YA_OFFSET_L         0x7B 
+#define MPU9250_YA_OFFSET_L         0x7B
 #define MPU9250_ZA_OFFSET_H         0x7D
 #define MPU9250_ZA_OFFSET_L         0x7E
 
 /* Registers AK8963 */
 #define AK8963_WIA      0x00 // Who am I
 #define AK8963_INFO     0x01
-#define AK8963_STATUS_1 0x02 
+#define AK8963_STATUS_1 0x02
 #define AK8963_HXL      0x03
 #define AK8963_HYL      0x05
 #define AK8963_HZL      0x07
@@ -115,75 +109,6 @@
 
 
 /* Enums */
-
-
-typedef enum MPU9250_BW_WO_DLPF {
-    MPU9250_BW_WO_DLPF_3600 = 0x02, 
-    MPU9250_BW_WO_DLPF_8800 = 0x01
-} MPU9250_bw_wo_dlpf;
-
-typedef enum MPU9250_DLPF {
-    MPU9250_DLPF_0, MPU9250_DLPF_1, MPU9250_DLPF_2, MPU9250_DLPF_3, MPU9250_DLPF_4, MPU9250_DLPF_5, 
-    MPU9250_DLPF_6, MPU9250_DLPF_7
-} MPU9250_dlpf;
-
-typedef enum MPU9250_GYRO_RANGE {
-    MPU9250_GYRO_RANGE_250, MPU9250_GYRO_RANGE_500, MPU9250_GYRO_RANGE_1000, MPU9250_GYRO_RANGE_2000
-} MPU9250_gyroRange;
-
-typedef enum MPU9250_ACC_RANGE {
-    MPU9250_ACC_RANGE_2G, MPU9250_ACC_RANGE_4G, MPU9250_ACC_RANGE_8G, MPU9250_ACC_RANGE_16G
-} MPU9250_accRange;
-
-typedef enum MPU9250_LOW_PWR_ACC_ODR {
-    MPU9250_LP_ACC_ODR_0_24, MPU9250_LP_ACC_ODR_0_49, MPU9250_LP_ACC_ODR_0_98, MPU9250_LP_ACC_ODR_1_95,
-    MPU9250_LP_ACC_ODR_3_91, MPU9250_LP_ACC_ODR_7_81, MPU9250_LP_ACC_ODR_15_63, MPU9250_LP_ACC_ODR_31_25,
-    MPU9250_LP_ACC_ODR_62_5, MPU9250_LP_ACC_ODR_125, MPU9250_LP_ACC_ODR_250, MPU9250_LP_ACC_ODR_500
-} MPU9250_lpAccODR;
-
-typedef enum MPU9250_INT_PIN_POL {
-    MPU9250_ACT_HIGH, MPU9250_ACT_LOW
-} MPU9250_intPinPol;
-
-typedef enum MPU9250_INT_TYPE {
-    MPU9250_DATA_READY = 0x01,
-    MPU9250_FIFO_OVF   = 0x10,
-    MPU9250_WOM_INT    = 0x40
-} MPU9250_intType;
-
-typedef enum MPU9250_WOM_EN {
-    MPU9250_WOM_DISABLE, MPU9250_WOM_ENABLE
-} MPU9250_womEn;
-
-typedef enum MPU9250_WOM_COMP {
-    MPU9250_WOM_COMP_DISABLE, MPU9250_WOM_COMP_ENABLE
-} MPU9250_womCompEn;
-
-typedef enum MPU9250_XYZ_ENABLE {
-    MPU9250_ENABLE_XYZ,  //all axes are enabled (default)
-    MPU9250_ENABLE_XY0,  // x, y enabled, z disabled
-    MPU9250_ENABLE_X0Z,   
-    MPU9250_ENABLE_X00,
-    MPU9250_ENABLE_0YZ,
-    MPU9250_ENABLE_0Y0,
-    MPU9250_ENABLE_00Z,
-    MPU9250_ENABLE_000,  // all axes disabled
-} MPU9250_xyzEn;
-
-typedef enum MPU9250_ORIENTATION {
-  MPU9250_FLAT, MPU9250_FLAT_1, MPU9250_XY, MPU9250_XY_1, MPU9250_YX, MPU9250_YX_1
-} MPU9250_orientation;
-
-typedef enum MPU9250_FIFO_MODE {
-    MPU9250_CONTINUOUS, MPU9250_STOP_WHEN_FULL
-} MPU9250_fifoMode;
-
-typedef enum MPU9250_FIFO_TYPE {
-    MPU9250_FIFO_ACC        = 0x08,
-    MPU9250_FIFO_GYR        = 0x70,
-    MPU9250_FIFO_ACC_GYR    = 0x78
-} MPU9250_fifo_type;
-
 typedef enum AK8963_OP_MODE {
     AK8963_PWR_DOWN           = 0x00,
     AK8963_TRIGGER_MODE       = 0x01,
@@ -192,25 +117,19 @@ typedef enum AK8963_OP_MODE {
     AK8963_FUSE_ROM_ACC_MODE  = 0x0F
 } AK8963_opMode;
 
-struct xyzFloat {
-    float x;
-    float y;
-    float z;
-};
-
 
 class MPU9250_WE
 {
-public: 
+public:
     /* Constructors */
-    
+
     MPU9250_WE(int addr);
     MPU9250_WE();
     MPU9250_WE(TwoWire *w, int addr);
     MPU9250_WE(TwoWire *w);
-   
+
     /* Basic settings */
-    
+
     bool init();
     uint8_t whoAmI();
     void autoOffsets();
@@ -227,40 +146,40 @@ public:
     void setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr);
     void enableAccAxes(MPU9250_xyzEn enable);
     void enableGyrAxes(MPU9250_xyzEn enable);
-        
+
     /* x,y,z results */
-     
+
     xyzFloat getAccRawValues();
     xyzFloat getCorrectedAccRawValues();
     xyzFloat getGValues();
     xyzFloat getAccRawValuesFromFifo();
     xyzFloat getCorrectedAccRawValuesFromFifo();
     xyzFloat getGValuesFromFifo();
-    float getResultantG(xyzFloat gVal); 
+    float getResultantG(xyzFloat gVal);
     float getTemperature();
     xyzFloat getGyrRawValues();
     xyzFloat getCorrectedGyrRawValues();
-    xyzFloat getGyrValues(); 
+    xyzFloat getGyrValues();
     xyzFloat getGyrValuesFromFifo();
     xyzFloat getMagValues();
-    
-        
-    /* Angles and Orientation */ 
-    
+
+
+    /* Angles and Orientation */
+
     xyzFloat getAngles();
     MPU9250_orientation getOrientation();
     String getOrientationAsString();
     float getPitch();
     float getRoll();
-    
-    /* Power, Sleep, Standby */ 
-    
+
+    /* Power, Sleep, Standby */
+
     void sleep(bool sleep);
     void enableCycle(bool cycle);
     void enableGyrStandby(bool gyroStandby);
-   
+
     /* Interrupts */
-   
+
     void setIntPinPolarity(MPU9250_intPinPol pol);
     void enableIntLatch(bool latch);
     void enableClearIntByAnyRead(bool clearByAnyRead);
@@ -270,9 +189,9 @@ public:
     uint8_t readAndClearInterrupts();
     void setWakeOnMotionThreshold(uint8_t womthresh);
     void enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn);
-       
+
     /* FIFO */
-    
+
     void startFifo(MPU9250_fifo_type fifo);
     void stopFifo();
     void enableFifo(bool fifo);
@@ -305,7 +224,7 @@ private:
     uint8_t gyrRangeFactor;
     uint8_t regVal;   // intermediate storage of register values
     MPU9250_fifo_type fifoType;
-    
+
     void correctAccRawValues();
     void correctGyrRawValues();
     void getAsaVals();

--- a/src/MPU9250_WE.h
+++ b/src/MPU9250_WE.h
@@ -24,88 +24,97 @@
 
 #include "MPU6500_WE.h"
 
-#define AK8963_ADDRESS 0x0C
+#define AK8963_ADDRESS MPU9250_WE::MAGNETOMETER_I2C_ADDRESS
 
-/* Registers MPU9250*/
-#define MPU9250_SELF_TEST_X_GYRO    0x00
-#define MPU9250_SELF_TEST_Y_GYRO    0x01
-#define MPU9250_SELF_TEST_Z_GYRO    0x02
-#define MPU9250_SELF_TEST_X_ACCEL   0x0D
-#define MPU9250_SELF_TEST_Y_ACCEL   0x0E
-#define MPU9250_SELF_TEST_Z_ACCEL   0x0F
-#define MPU9250_XG_OFFSET_H         0x13
-#define MPU9250_XG_OFFSET_L         0x14
-#define MPU9250_YG_OFFSET_H         0x15
-#define MPU9250_YG_OFFSET_L         0x16
-#define MPU9250_ZG_OFFSET_H         0x17
-#define MPU9250_ZG_OFFSET_L         0x18
-#define MPU9250_SMPLRT_DIV          0x19
-#define MPU9250_CONFIG              0x1A
-#define MPU9250_GYRO_CONFIG         0x1B
-#define MPU9250_ACCEL_CONFIG        0x1C
-#define MPU9250_ACCEL_CONFIG_2      0x1D
-#define MPU9250_LP_ACCEL_ODR        0x1E
-#define MPU9250_WOM_THR             0x1F
-#define MPU9250_FIFO_EN             0x23
-#define MPU9250_I2C_MST_CTRL        0x24
-#define MPU9250_I2C_SLV0_ADDR       0x25
-#define MPU9250_I2C_SLV0_REG        0x26
-#define MPU9250_I2C_SLV0_CTRL       0x27
-#define MPU9250_I2C_MST_STATUS      0x36
-#define MPU9250_INT_PIN_CFG         0x37
-#define MPU9250_INT_ENABLE          0x38
-#define MPU9250_INT_STATUS          0x3A
-#define MPU9250_ACCEL_OUT           0x3B // accel data registers begin
-#define MPU9250_TEMP_OUT            0x41
-#define MPU9250_GYRO_OUT            0x43 // gyro data registers begin
-#define MPU9250_EXT_SLV_SENS_DATA_00    0x49
-#define MPU9250_I2C_SLV0_DO         0x63
-#define MPU9250_I2C_MST_DELAY_CTRL  0x67
-#define MPU9250_SIGNAL_PATH_RESET   0x68
-#define MPU9250_MOT_DET_CTRL        0x69
-#define MPU9250_USER_CTRL           0x6A
-#define MPU9250_PWR_MGMT_1          0x6B
-#define MPU9250_PWR_MGMT_2          0x6C
-#define MPU9250_FIFO_COUNT          0x72 // 0x72 is COUNT_H
-#define MPU9250_FIFO_R_W            0x74
-#define MPU9250_WHO_AM_I            0x75
-#define MPU9250_XA_OFFSET_H         0x77
-#define MPU9250_XA_OFFSET_L         0x78
-#define MPU9250_YA_OFFSET_H         0x7A
-#define MPU9250_YA_OFFSET_L         0x7B
-#define MPU9250_ZA_OFFSET_H         0x7D
-#define MPU9250_ZA_OFFSET_L         0x7E
+/*
+ * Please note that the following '#define's are only kept for backward-compatibility.
+ * They do only reference correctly typed and static [i.e. uniquely instantiated]
+ * values defined in the respective class.
+ * If you do want to change a value, do not change any of these '#define's but
+ * instead the actual referenced value.
+ *
+ */
+
+/* Registers MPU9250 */
+#define MPU9250_SELF_TEST_X_GYRO        MPU6500_WE::REGISTER_SELF_TEST_X_GYRO
+#define MPU9250_SELF_TEST_Y_GYRO        MPU6500_WE::REGISTER_SELF_TEST_Y_GYRO
+#define MPU9250_SELF_TEST_Z_GYRO        MPU6500_WE::REGISTER_SELF_TEST_Z_GYRO
+#define MPU9250_SELF_TEST_X_ACCEL       MPU6500_WE::REGISTER_SELF_TEST_X_ACCEL
+#define MPU9250_SELF_TEST_Y_ACCEL       MPU6500_WE::REGISTER_SELF_TEST_Y_ACCEL
+#define MPU9250_SELF_TEST_Z_ACCEL       MPU6500_WE::REGISTER_SELF_TEST_Z_ACCEL
+#define MPU9250_XG_OFFSET_H             MPU6500_WE::REGISTER_XG_OFFSET_H
+#define MPU9250_XG_OFFSET_L             MPU6500_WE::REGISTER_XG_OFFSET_L
+#define MPU9250_YG_OFFSET_H             MPU6500_WE::REGISTER_YG_OFFSET_H
+#define MPU9250_YG_OFFSET_L             MPU6500_WE::REGISTER_YG_OFFSET_L
+#define MPU9250_ZG_OFFSET_H             MPU6500_WE::REGISTER_ZG_OFFSET_H
+#define MPU9250_ZG_OFFSET_L             MPU6500_WE::REGISTER_ZG_OFFSET_L
+#define MPU9250_SMPLRT_DIV              MPU6500_WE::REGISTER_SMPLRT_DIV
+#define MPU9250_CONFIG                  MPU6500_WE::REGISTER_CONFIG
+#define MPU9250_GYRO_CONFIG             MPU6500_WE::REGISTER_GYRO_CONFIG
+#define MPU9250_ACCEL_CONFIG            MPU6500_WE::REGISTER_ACCEL_CONFIG
+#define MPU9250_ACCEL_CONFIG_2          MPU6500_WE::REGISTER_ACCEL_CONFIG_2
+#define MPU9250_LP_ACCEL_ODR            MPU6500_WE::REGISTER_LP_ACCEL_ODR
+#define MPU9250_WOM_THR                 MPU6500_WE::REGISTER_WOM_THR
+#define MPU9250_FIFO_EN                 MPU6500_WE::REGISTER_FIFO_EN
+#define MPU9250_I2C_MST_CTRL            MPU6500_WE::REGISTER_I2C_MST_CTRL
+#define MPU9250_I2C_SLV0_ADDR           MPU6500_WE::REGISTER_I2C_SLV0_ADDR
+#define MPU9250_I2C_SLV0_REG            MPU6500_WE::REGISTER_I2C_SLV0_REG
+#define MPU9250_I2C_SLV0_CTRL           MPU6500_WE::REGISTER_I2C_SLV0_CTRL
+#define MPU9250_I2C_MST_STATUS          MPU6500_WE::REGISTER_I2C_MST_STATUS
+#define MPU9250_INT_PIN_CFG             MPU6500_WE::REGISTER_INT_PIN_CFG
+#define MPU9250_INT_ENABLE              MPU6500_WE::REGISTER_INT_ENABLE
+#define MPU9250_INT_STATUS              MPU6500_WE::REGISTER_INT_STATUS
+#define MPU9250_ACCEL_OUT               MPU6500_WE::REGISTER_ACCEL_OUT
+#define MPU9250_TEMP_OUT                MPU6500_WE::REGISTER_TEMP_OUT
+#define MPU9250_GYRO_OUT                MPU6500_WE::REGISTER_GYRO_OUT
+#define MPU9250_EXT_SLV_SENS_DATA_00    MPU6500_WE::REGISTER_EXT_SLV_SENS_DATA_00
+#define MPU9250_I2C_SLV0_DO             MPU6500_WE::REGISTER_I2C_SLV0_DO
+#define MPU9250_I2C_MST_DELAY_CTRL      MPU6500_WE::REGISTER_I2C_MST_DELAY_CTRL
+#define MPU9250_SIGNAL_PATH_RESET       MPU6500_WE::REGISTER_SIGNAL_PATH_RESET
+#define MPU9250_MOT_DET_CTRL            MPU6500_WE::REGISTER_MOT_DET_CTRL
+#define MPU9250_USER_CTRL               MPU6500_WE::REGISTER_USER_CTRL
+#define MPU9250_PWR_MGMT_1              MPU6500_WE::REGISTER_PWR_MGMT_1
+#define MPU9250_PWR_MGMT_2              MPU6500_WE::REGISTER_PWR_MGMT_2
+#define MPU9250_FIFO_COUNT              MPU6500_WE::REGISTER_FIFO_COUNT
+#define MPU9250_FIFO_R_W                MPU6500_WE::REGISTER_FIFO_R_W
+#define MPU9250_WHO_AM_I                MPU6500_WE::REGISTER_WHO_AM_I
+#define MPU9250_XA_OFFSET_H             MPU6500_WE::REGISTER_XA_OFFSET_H
+#define MPU9250_XA_OFFSET_L             MPU6500_WE::REGISTER_XA_OFFSET_L
+#define MPU9250_YA_OFFSET_H             MPU6500_WE::REGISTER_YA_OFFSET_H
+#define MPU9250_YA_OFFSET_L             MPU6500_WE::REGISTER_YA_OFFSET_L
+#define MPU9250_ZA_OFFSET_H             MPU6500_WE::REGISTER_ZA_OFFSET_H
+#define MPU9250_ZA_OFFSET_L             MPU6500_WE::REGISTER_ZA_OFFSET_L
 
 /* Registers AK8963 */
-#define AK8963_WIA      0x00 // Who am I
-#define AK8963_INFO     0x01
-#define AK8963_STATUS_1 0x02
-#define AK8963_HXL      0x03
-#define AK8963_HYL      0x05
-#define AK8963_HZL      0x07
-#define AK8963_STATUS_2 0x09
-#define AK8963_CNTL_1   0x0A
-#define AK8963_CNTL_2   0x0B
-#define AK8963_ASTC     0x0C // Self Test
-#define AK8963_I2CDIS   0x0F
-#define AK8963_ASAX     0x10
-#define AK8963_ASAY     0x11
-#define AK8963_ASAZ     0x12
+#define AK8963_WIA                      MPU9250_WE::REGISTER_AK8963_WIA      // Who am I
+#define AK8963_INFO                     MPU9250_WE::REGISTER_AK8963_INFO
+#define AK8963_STATUS_1                 MPU9250_WE::REGISTER_AK8963_STATUS_1
+#define AK8963_HXL                      MPU9250_WE::REGISTER_AK8963_HXL
+#define AK8963_HYL                      MPU9250_WE::REGISTER_AK8963_HYL
+#define AK8963_HZL                      MPU9250_WE::REGISTER_AK8963_HZL
+#define AK8963_STATUS_2                 MPU9250_WE::REGISTER_AK8963_STATUS_2
+#define AK8963_CNTL_1                   MPU9250_WE::REGISTER_AK8963_CNTL_1
+#define AK8963_CNTL_2                   MPU9250_WE::REGISTER_AK8963_CNTL_2
+#define AK8963_ASTC                     MPU9250_WE::REGISTER_AK8963_ASTC     // Self Test
+#define AK8963_I2CDIS                   MPU9250_WE::REGISTER_AK8963_I2CDIS
+#define AK8963_ASAX                     MPU9250_WE::REGISTER_AK8963_ASAX
+#define AK8963_ASAY                     MPU9250_WE::REGISTER_AK8963_ASAY
+#define AK8963_ASAZ                     MPU9250_WE::REGISTER_AK8963_ASAZ
 
 /* Register Values */
-#define MPU9250_RESET       0x80
-#define MPU9250_BYPASS_EN   0x02
-#define MPU9250_I2C_MST_EN  0x20
-#define MPU9250_CLK_SEL_PLL 0x01
-#define AK8963_16_BIT       0x10
-#define AK8963_OVF          0x08
-#define AK8963_READ         0x80
+#define MPU9250_RESET                   MPU6500_WE::REGISTER_VALUE_RESET
+#define MPU9250_BYPASS_EN               MPU6500_WE::REGISTER_VALUE_BYPASS_EN
+#define MPU9250_I2C_MST_EN              MPU6500_WE::REGISTER_VALUE_I2C_MST_EN
+#define MPU9250_CLK_SEL_PLL             MPU6500_WE::REGISTER_VALUE_CLK_SEL_PLL
+#define AK8963_16_BIT                   MPU9250_WE::REGISTER_VALUE_AK8963_16_BIT
+#define AK8963_OVF                      MPU9250_WE::REGISTER_VALUE_AK8963_OVF
+#define AK8963_READ                     MPU9250_WE::REGISTER_VALUE_AK8963_READ
 
 /* Others */
-#define MPU9250_ROOM_TEMP_OFFSET    0.0f
-#define MPU9250_T_SENSITIVITY       333.87f
-#define MPU9250_WHO_AM_I_CODE       0x71
-#define AK8963_WHO_AM_I_CODE        0x48
+#define MPU9250_ROOM_TEMP_OFFSET        MPU6500_WE::ROOM_TEMPERATURE_OFFSET
+#define MPU9250_T_SENSITIVITY           MPU6500_WE::TEMPERATURE_SENSITIVITY
+#define MPU9250_WHO_AM_I_CODE           MPU9250_WE::WHO_AM_I_CODE
+#define AK8963_WHO_AM_I_CODE            MPU9250_WE::MAGNETOMETER_WHO_AM_I_CODE
 
 
 /* Enums */
@@ -121,6 +130,34 @@ typedef enum AK8963_OP_MODE {
 class MPU9250_WE : public MPU6500_WE
 {
 public:
+
+
+    /* Registers AK8963 */
+    static uint8_t constexpr REGISTER_AK8963_WIA            = 0x00; // Who am I
+    static uint8_t constexpr REGISTER_AK8963_INFO           = 0x01;
+    static uint8_t constexpr REGISTER_AK8963_STATUS_1       = 0x02;
+    static uint8_t constexpr REGISTER_AK8963_HXL            = 0x03;
+    static uint8_t constexpr REGISTER_AK8963_HYL            = 0x05;
+    static uint8_t constexpr REGISTER_AK8963_HZL            = 0x07;
+    static uint8_t constexpr REGISTER_AK8963_STATUS_2       = 0x09;
+    static uint8_t constexpr REGISTER_AK8963_CNTL_1         = 0x0A;
+    static uint8_t constexpr REGISTER_AK8963_CNTL_2         = 0x0B;
+    static uint8_t constexpr REGISTER_AK8963_ASTC           = 0x0C; // Self Test
+    static uint8_t constexpr REGISTER_AK8963_I2CDIS         = 0x0F;
+    static uint8_t constexpr REGISTER_AK8963_ASAX           = 0x10;
+    static uint8_t constexpr REGISTER_AK8963_ASAY           = 0x11;
+    static uint8_t constexpr REGISTER_AK8963_ASAZ           = 0x12;
+
+    /* Register Values */
+    static uint8_t constexpr REGISTER_VALUE_AK8963_16_BIT   = 0x10;
+    static uint8_t constexpr REGISTER_VALUE_AK8963_OVF      = 0x08;
+    static uint8_t constexpr REGISTER_VALUE_AK8963_READ     = 0x80;
+
+    /* Others */
+    static uint8_t constexpr WHO_AM_I_CODE                  = 0x71;
+    static uint8_t constexpr MAGNETOMETER_I2C_ADDRESS       = 0x0C;
+    static uint8_t constexpr MAGNETOMETER_WHO_AM_I_CODE     = 0x48;
+
     /* Constructors */
 
     MPU9250_WE(int addr);

--- a/src/MPU9250_WE.h
+++ b/src/MPU9250_WE.h
@@ -118,7 +118,7 @@ typedef enum AK8963_OP_MODE {
 } AK8963_opMode;
 
 
-class MPU9250_WE
+class MPU9250_WE : public MPU6500_WE
 {
 public:
     /* Constructors */
@@ -131,75 +131,10 @@ public:
     /* Basic settings */
 
     bool init();
-    uint8_t whoAmI();
-    void autoOffsets();
-    void setAccOffsets(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax);
-    void setGyrOffsets(float xOffset, float yOffset, float zOffset);
-    void setGyrDLPF(MPU9250_dlpf dlpf);
-    void setSampleRateDivider(uint8_t splRateDiv);
-    void setGyrRange(MPU9250_gyroRange gyroRange);
-    void enableGyrDLPF();
-    void disableGyrDLPF(MPU9250_bw_wo_dlpf bw);
-    void setAccRange(MPU9250_accRange accRange);
-    void enableAccDLPF(bool enable);
-    void setAccDLPF(MPU9250_dlpf dlpf);
-    void setLowPowerAccDataRate(MPU9250_lpAccODR lpaodr);
-    void enableAccAxes(MPU9250_xyzEn enable);
-    void enableGyrAxes(MPU9250_xyzEn enable);
 
     /* x,y,z results */
 
-    xyzFloat getAccRawValues();
-    xyzFloat getCorrectedAccRawValues();
-    xyzFloat getGValues();
-    xyzFloat getAccRawValuesFromFifo();
-    xyzFloat getCorrectedAccRawValuesFromFifo();
-    xyzFloat getGValuesFromFifo();
-    float getResultantG(xyzFloat gVal);
-    float getTemperature();
-    xyzFloat getGyrRawValues();
-    xyzFloat getCorrectedGyrRawValues();
-    xyzFloat getGyrValues();
-    xyzFloat getGyrValuesFromFifo();
     xyzFloat getMagValues();
-
-
-    /* Angles and Orientation */
-
-    xyzFloat getAngles();
-    MPU9250_orientation getOrientation();
-    String getOrientationAsString();
-    float getPitch();
-    float getRoll();
-
-    /* Power, Sleep, Standby */
-
-    void sleep(bool sleep);
-    void enableCycle(bool cycle);
-    void enableGyrStandby(bool gyroStandby);
-
-    /* Interrupts */
-
-    void setIntPinPolarity(MPU9250_intPinPol pol);
-    void enableIntLatch(bool latch);
-    void enableClearIntByAnyRead(bool clearByAnyRead);
-    void enableInterrupt(MPU9250_intType intType);
-    void disableInterrupt(MPU9250_intType intType);
-    bool checkInterrupt(uint8_t source, MPU9250_intType type);
-    uint8_t readAndClearInterrupts();
-    void setWakeOnMotionThreshold(uint8_t womthresh);
-    void enableWakeOnMotion(MPU9250_womEn womEn, MPU9250_womCompEn womCompEn);
-
-    /* FIFO */
-
-    void startFifo(MPU9250_fifo_type fifo);
-    void stopFifo();
-    void enableFifo(bool fifo);
-    void resetFifo();
-    int16_t getFifoCount();
-    void setFifoMode(MPU9250_fifoMode mode);
-    int16_t getNumberOfFifoDataSets();
-    void findFifoBegin();
 
     /* Magnetometer */
 
@@ -209,39 +144,18 @@ public:
     void startMagMeasurement();
 
 protected:
-
-    bool init(uint8_t const expectedValue);
-
-private:
-    TwoWire *_wire;
-    int i2cAddress;
-    xyzFloat accRawVal;
-    xyzFloat gyrRawVal;
-    xyzFloat accOffsetVal;
-    xyzFloat gyrOffsetVal;
-    xyzFloat magCorrFactor;
-    uint8_t accRangeFactor;
-    uint8_t gyrRangeFactor;
-    uint8_t regVal;   // intermediate storage of register values
-    MPU9250_fifo_type fifoType;
-
-    void correctAccRawValues();
-    void correctGyrRawValues();
     void getAsaVals();
-    void reset_MPU9250();
-    void enableI2CMaster();
     void enableMagDataRead(uint8_t reg, uint8_t bytes);
     void resetMagnetometer();
-    void writeMPU9250Register(uint8_t reg, uint8_t val);
     void writeAK8963Register(uint8_t reg, uint8_t val);
-    uint8_t readMPU9250Register8(uint8_t reg);
     uint8_t readAK8963Register8(uint8_t reg);
     uint64_t readAK8963Data();
-    int16_t readMPU9250Register16(uint8_t reg);
-    uint64_t readMPU9250Register3x16(uint8_t reg);
-    xyzFloat readMPU9250xyzValFromFifo();
     void setMagnetometer16Bit();
     uint8_t getStatus2Register();
+
+private:
+    xyzFloat magCorrFactor;
+
 };
 
 #endif


### PR DESCRIPTION
I tried to use a MPU-6500 and stumbled upon your great library. The only problems I saw were, that
 - the init-routine always failed,
 - I only received 0-values for the magnetometer.

Once I understood that this is due to the MPU-6500 having a different identification value [WHO_AM_I] and no magnetometer, I came up with this sketch.
From a conceptual point of view I would have liked to design this the other way round, i.e. MPU5250 should have inherited from MPU6500 - but I did not want to redesign everything without having asked your views regarding this.
Do you have some experience with the MPU-6500?
Mine is not too deep and the proposed changes come from a quick comparison of the register map descriptions of both devices. They seem - apart from some small naming differences - to be identical.